### PR TITLE
Do not use http download for cloudera manager

### DIFF
--- a/salt/cdh/cloudera-manager.sls
+++ b/salt/cdh/cloudera-manager.sls
@@ -6,9 +6,9 @@ include:
 cloudera-manager-add_cloudera_manager_repository:
   pkgrepo.managed:
     - humanname: Cloudera Manager
-    - name: deb [arch=amd64] http://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm trusty-cm{{cm_ver}} contrib
+    - name: deb [arch=amd64] https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm trusty-cm{{cm_ver}} contrib
     - dist: trusty-cm{{cm_ver}}
-    - key_url: http://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key
+    - key_url: https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key
     - refresh: True
     - file: /etc/apt/sources.list.d/cloudera.list
 


### PR DESCRIPTION
This is vulnerable to man in the middle attack, and since cloudera
offer https, there is no reason to use http.

Fix CVE-2016-1000036