### PR TITLE
Add a simple minimal notebook to explain basic usage

### DIFF
--- a/salt/jupyter/files/PNDA minimal notebook.ipynb
+++ b/salt/jupyter/files/PNDA minimal notebook.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Minimal PNDA Jupyter notebook\n",
+    "\n",
+    "`%matplotlib notebook` must be set before `import matplotlib.pyplot as plt` or plotting with matplotlib will fail "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib notebook\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sys\n",
+    "import pandas as pd\n",
+    "import matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(u'▶ Python version ' + sys.version)\n",
+    "print(u'▶ Pandas version ' + pd.__version__)\n",
+    "print(u'▶ Matplotlib version ' + matplotlib.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "values = np.random.rand(100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(data=values, columns=['RandomValue'])\n",
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df.plot()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "PySpark (Python2)",
+   "language": "python",
+   "name": "pyspark"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/salt/jupyter/init.sls
+++ b/salt/jupyter/init.sls
@@ -60,6 +60,11 @@ jupyter-create_hub_configuration:
     - source: salt://jupyter/templates/jupyterhub_config.py.tpl
     - template: jinja
 
+jupyter-copy_simple_initial_notebook:
+  file.managed:
+    - source: 'salt://jupyter/files/PNDA minimal notebook.ipynb'
+    - name: '/home/{{ pillar['pnda']['user'] }}/PNDA minimal notebook.ipynb'
+
 # install jupyterhub kernels (python2, python3, and pyspark)
 jupyter-create_kernels_dir:
   file.directory:


### PR DESCRIPTION
In particular, it uses '%matplolib notebook' instead of '%matplotlib
inline'; it make plots nicer in notebooks.
It also emphasis the fact that '%matplotlib ...' must be executed before
'import matplotlib ...' if you want plots to be displayed.

PNDA-1914