### PR TITLE
Tell upstart to not log console output of data-logger

### DIFF
--- a/salt/console-backend/data-logger.sls
+++ b/salt/console-backend/data-logger.sls
@@ -68,6 +68,7 @@ console-backend-copy_data_logger_upstart:
     - source: salt://console-backend/templates/backend_nodejs_app.conf.tpl
     - template: jinja
     - defaults:
+        no_console_log: True
         host_ip: {{ host_ip }}
         backend_app_port: {{ backend_app_port }}
         app_dir: {{ app_dir }}

--- a/salt/console-backend/templates/backend_nodejs_app.conf.tpl
+++ b/salt/console-backend/templates/backend_nodejs_app.conf.tpl
@@ -1,6 +1,9 @@
 start on runlevel [2345]
 stop on runlevel [016]
 
+{%- if no_console_log is defined and no_console_log %}
+console none
+{%- endif %}
 normal exit 0
 respawn
 respawn limit unlimited


### PR DESCRIPTION
A new 'no_console_log' template variable was introduced to enable or
disable console logging in upstart logs.

PNDA-2009