### PR TITLE
 Update zookeeper in order to be able to install a dedicated version

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -27,6 +27,9 @@ jupyterhub:
   version: 0.6.1
   confdir: /etc/jupyterhub
 
+zookeeper:
+  version: 3.4.6
+
 kafka:
   version: 0.9.0.1
   config:

--- a/salt/zookeeper/files/templates/environment.tpl
+++ b/salt/zookeeper/files/templates/environment.tpl
@@ -1,5 +1,5 @@
 NAME=zookeeper
-ZOOCFGDIR=/etc/$NAME/conf
+ZOOCFGDIR={{ conf_dir }}
 
 # TODO this is really ugly
 # How to find out, which jars are needed?

--- a/salt/zookeeper/files/templates/environment.tpl
+++ b/salt/zookeeper/files/templates/environment.tpl
@@ -1,10 +1,8 @@
 NAME=zookeeper
-ZOOCFGDIR={{ conf_dir }}
+ZOOCFGDIR={{ install_dir }}/conf
+ZOOLIBDIR={{ install_dir }}/lib
 
-# TODO this is really ugly
-# How to find out, which jars are needed?
-# seems, that log4j requires the log4j.properties file to be in the classpath
-CLASSPATH="$ZOOCFGDIR:/usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar"
+CLASSPATH="$ZOOCFGDIR:$ZOOLIBDIR/jline-0.9.94.jar:$ZOOLIBDIR/log4j-1.2.16.jar:$ZOOLIBDIR/netty-3.7.0.Final.jar:$ZOOLIBDIR/slf4j-api-1.6.1.jar:$ZOOLIBDIR/slf4j-log4j12-1.6.1.jar:/usr/share/java/zookeeper.jar"
 
 ZOOCFG="$ZOOCFGDIR/zoo.cfg"
 ZOO_LOG_DIR=/var/log/pnda/$NAME

--- a/salt/zookeeper/files/templates/zoo.cfg.tpl
+++ b/salt/zookeeper/files/templates/zoo.cfg.tpl
@@ -1,59 +1,10 @@
-# http://hadoop.apache.org/zookeeper/docs/current/zookeeperAdmin.html
-
-# The number of milliseconds of each tick
 tickTime=2000
-# The number of ticks that the initial
-# synchronization phase can take
 initLimit=20
-# The number of ticks that can pass between
-# sending a request and getting an acknowledgement
 syncLimit=5
-# the directory where the snapshot is stored.
-dataDir=/var/lib/zookeeper
-# Place the dataLogDir to a separate physical disc for better performance
-# dataLogDir=/disk2/zookeeper
-
-# the port at which the clients will connect
+dataDir={{ data_dir }}
 clientPort=2181
-
-# specify all zookeeper servers
-# The fist port is used by followers to connect to the leader
-# The second one is used for leader election
-
 {%- for node in nodes %}
 server.{{ node.id }}={{ node.ip }}:2888:3888
 {%- endfor %}
-
-# To avoid seeks ZooKeeper allocates space in the transaction log file in
-# blocks of preAllocSize kilobytes. The default block size is 64M. One reason
-# for changing the size of the blocks is to reduce the block size if snapshots
-# are taken more often. (Also, see snapCount).
-#preAllocSize=65536
-
-# Clients can submit requests faster than ZooKeeper can process them,
-# especially if there are a lot of clients. To prevent ZooKeeper from running
-# out of memory due to queued requests, ZooKeeper will throttle clients so that
-# there is no more than globalOutstandingLimit outstanding requests in the
-# system. The default limit is 1,000.ZooKeeper logs transactions to a
-# transaction log. After snapCount transactions are written to a log file a
-# snapshot is started and a new transaction log file is started. The default
-# snapCount is 10,000.
-#snapCount=1000
-
-# If this option is defined, requests will be will logged to a trace file named
-# traceFile.year.month.day.
-#traceFile=
-
-# Leader accepts client connections. Default value is "yes". The leader machine
-# coordinates updates. For higher update throughput at thes slight expense of
-# read throughput the leader can be configured to not accept clients and focus
-# on coordination.
-#leaderServes=yes
-
 maxClientCnxns=100
-
-# If this option is changed, the system property must be set on all servers and clients otherwise problems will arise
-#jute.maxbuffer=10000000
-
-# Sets the timeout value for opening connections for leader election notifications
 cnxTimeout=10

--- a/salt/zookeeper/files/templates/zookeeper.init.conf.tpl
+++ b/salt/zookeeper/files/templates/zookeeper.init.conf.tpl
@@ -1,0 +1,27 @@
+description "zookeeper centralized coordination service"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+limit nofile 8192 8192
+
+pre-start script
+    [ -r "/usr/share/java/zookeeper.jar" ] || exit 0
+    [ -r "{{ conf_dir }}/environment" ] || exit 0
+    . {{ conf_dir }}/environment
+    [ -d $ZOO_LOG_DIR ] || mkdir -p $ZOO_LOG_DIR
+    chown $USER:$GROUP $ZOO_LOG_DIR
+end script
+
+script
+    . {{ conf_dir }}/environment
+    [ -r /etc/default/zookeeper ] && . /etc/default/zookeeper
+    if [ -z "$JMXDISABLE" ]; then
+        JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=$JMXLOCALONLY"
+    fi
+    exec start-stop-daemon --start -c $USER --exec $JAVA --name zookeeper \
+    	-- -cp $CLASSPATH $JAVA_OPTS -Dzookeeper.log.dir=${ZOO_LOG_DIR} \
+      	-Dzookeeper.root.logger=${ZOO_LOG4J_PROP} $ZOOMAIN $ZOOCFG
+end script


### PR DESCRIPTION
Do not rely on apt for installing zookeeper and now default version is 3.4.6

PNDA-2016