### PR TITLE
Re-raise exceptions from cm_setup

### DIFF
--- a/salt/cdh/files/cm_setup.py
+++ b/salt/cdh/files/cm_setup.py
@@ -157,6 +157,7 @@ def create_cluster(api, cluster_name):
         cluster.add_hosts([host.hostId for host in hosts])
     except Exception as exception:
         logging.error("Error while creating cluster", exc_info=True)
+        raise
 
     return cluster
 
@@ -310,6 +311,7 @@ def create_cms(cloudera_manager, nodes):
 
     except Exception as exception:
         logging.error("Error while creating CMS", exc_info=True)
+        raise
 
     return cms
 
@@ -355,7 +357,7 @@ def create_mysql_connector_symlink(user, key, ip_addr, target_dir):
         setup_remotehost(config)
     except Exception as exception:
         logging.error("Error while creating mysql symlink", exc_info=True)
-
+        raise
 
 def create_hdfs_dirs(yarn):
     wait_on_success(yarn.create_yarn_job_history_dir())
@@ -376,7 +378,7 @@ def create_hive_tmp(user, key, ip_addr):
         setup_remotehost(config)
     except Exception as exception:
         logging.error("Error while creating hive temporary directory", exc_info=True)
-
+        raise
 
 def assign_roles(service, roles, nodes):
 
@@ -462,6 +464,8 @@ def expand_services(cluster, nodes):
 
     except Exception as exception:
         logging.error("Error while expanding services", exc_info=True)
+        raise
+
     return {'hdfs': hdfs, 'hbase': hbase, 'mapred': mapred, 'impala': impala}
 
 
@@ -623,6 +627,8 @@ def create_services(user, key, cluster, nodes, isHA_enabled):
 
     except Exception as exception:
         logging.error("Error while creating services", exc_info=True)
+        raise
+
     return {
         'hdfs': hdfs,
         'zookeeper': zoo_k,


### PR DESCRIPTION
Re-raise exceptions from cm_setup so that the process exits with a
non-zero exit code when an error occurs in hadoop setup.

PNDA-2022.