### PR TITLE
Include python-pip in graphite sls

### DIFF
--- a/salt/graphite/init.sls
+++ b/salt/graphite/init.sls
@@ -1,5 +1,8 @@
 # based on http://graphite-api.readthedocs.io/en/latest/deployment.html#nginx-uwsgi
 
+include:
+  - python-pip
+
 graphite-reqs:
   pkg.installed:
     - refresh: True


### PR DESCRIPTION
python-pip is included as a dependency to ensure the correct version of pip is used when installing graphite.

PNDA-2143