### PR TITLE
Pin version of cariocffi and graphite-api

### DIFF
--- a/salt/graphite/init.sls
+++ b/salt/graphite/init.sls
@@ -20,8 +20,11 @@ libffi-dev:
 libapache2-mod-wsgi:
   pkg.installed
 
-graphite-api:
-  pip.installed
+install-graphite-api:
+  pip.installed:
+    - pkgs:
+      - cairocffi == 0.6
+      - graphite-api == 1.1.3
 
 graphite-carbon:
   pkg.installed


### PR DESCRIPTION
cariocffi 0.7 was seen to fail to install

PNDA-2305