### PR TITLE
Check if hue user exists before creating it

### DIFF
--- a/salt/cdh/templates/hue-user-setup.sh.tpl
+++ b/salt/cdh/templates/hue-user-setup.sh.tpl
@@ -2,8 +2,26 @@
 {% set pnda_password = pillar['pnda']['password'] %}
 export HUE_CONF_DIR="/var/run/cloudera-scm-agent/process/`ls -alrt /var/run/cloudera-scm-agent/process | grep HUE | tail -1 | awk '{print $9}'`"
 export HUE_DATABASE_PASSWORD=hue
-export HUE_IGNORE_PASSWORD_SCRIPT_ERRORS=1 
+export HUE_IGNORE_PASSWORD_SCRIPT_ERRORS=1
 cd /opt/cloudera/parcels/CDH/lib/hue/
+echo 'checking if user already exists'
+build/env/bin/hue  shell <<CHECKUSER
+import sys
+from django.contrib.auth.models import User
+ 
+a = User.objects.get(username='{{ pnda_user }}')
+code = 1 if '{{ pnda_user }}' == str(a) else 0
+sys.exit(code)
+CHECKUSER
+result=$?
+echo 'checked if user already exists'
+if [ $result -eq 1 ]
+then
+  echo "User already exists, not creating one or setting its password"
+  exit
+else
+  echo "User not found, will create one"
+fi
 build/env/bin/hue createsuperuser --username={{ pnda_user }} --noinput --email not@used.com
 build/env/bin/hue  shell <<CREATE
 from django.contrib.auth.models import User


### PR DESCRIPTION
Explicit check on whether the user exists rather than relying on an
error being thrown and caught if it already exists.

PNDA-2302