### PR TITLE
hdfs-cleaner creates the archive container it needs

### DIFF
--- a/salt/hdfs-cleaner/templates/properties.json.tpl
+++ b/salt/hdfs-cleaner/templates/properties.json.tpl
@@ -20,5 +20,13 @@
     "old_dirs_to_clean": [
         {"name": "/user/gobblin/work/metrics", "age_seconds": 172800}
     ],
-    "swift_repo": "{{ archive_type }}://{{ container }}{{ archive_service }}/{{ repo_path }}"
+    "swift_repo": "{{ archive_type }}://{{ container }}{{ archive_service }}/{{ repo_path }}",
+    "container_name": "{{ container }}",
+    "s3_region": "{{ salt['pillar.get']('aws.archive_region', '') }}",
+    "s3_access_key": "{{ salt['pillar.get']('aws.archive_key', '') }}",
+    "s3_secret_access_key": "{{ salt['pillar.get']('aws.archive_secret', '') }}",
+    "swift_account":"{{ salt['pillar.get']('keystone.tenant', '') }}",
+    "swift_user": "{{ salt['pillar.get']('keystone.user', '') }}",
+    "swift_key": "{{ salt['pillar.get']('keystone.password', '') }}",
+    "swift_auth_url": "{{ salt['pillar.get']('keystone.auth_url', '') }}"
 }


### PR DESCRIPTION
The config file is wired up with the credentials it needs to create the
container in swift or s3.

PNDA-2284