### PR TITLE
Reduce ES data retention for pico

### DIFF
--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -11,6 +11,9 @@
         },
         "cdh.setup_hadoop": {
             "template_file": "cfg_pico.py"
+        },
+        "curator": {
+            "days_to_keep": 1
         }
     }
 }

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -11,6 +11,9 @@
         },
         "cdh.setup_hadoop": {
             "template_file": "cfg_standard.py"
+        },
+        "curator": {
+            "days_to_keep": 6
         }
     }
 }

--- a/salt/curator/init.sls
+++ b/salt/curator/init.sls
@@ -1,3 +1,5 @@
+{% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
+
 include:
   - python-pip
 
@@ -14,4 +16,5 @@ curator-update-crontab-inc-curator:
     - user: root
     - minute: 01
     - hour: 00
-    - name: /usr/local/bin/curator delete indices --older-than 6 --time-unit days --prefix logstash- --timestring \%Y.\%m.\%d >> /tmp/curator.log 2>&1
+    - name: /usr/local/bin/curator delete indices --older-than {{ flavor_cfg.days_to_keep }} --time-unit days --prefix logstash- --timestring \%Y.\%m.\%d >> /tmp/curator.log 2>&1
+


### PR DESCRIPTION
Keep 1 day of ES data for pico, standard stays at 6 days. Using flavor
specific pillar config to do this.

PNDA-2435