### PR TITLE
Aggregating redundant services into common VM's.

### DIFF
--- a/salt/cdh/templates/cfg_standard.py.tpl
+++ b/salt/cdh/templates/cfg_standard.py.tpl
@@ -268,12 +268,12 @@ HBASE_CFG = {
             {
                 "name": "master",
                 "type": "MASTER",
-                "target": "MGR03"
+                "target": "MGR01"
             },
             {
                 "name": "master_sec",
                 "type": "MASTER",
-                "target": "MGR04"
+                "target": "MGR02"
             },
             {
                 "name": "regionserver",


### PR DESCRIPTION
Collocating hbase master service with the hbase gw service to allow
anti-affinity group definition.

This depends on the new flavor definitions in https://github.com/pndaproject/pnda-heat-templates/blob/PNDA-2380/templates/standard/instance_flavors.yaml