### PR TITLE
Cloudera manager uses external mqsql database

### DIFF
--- a/salt/cdh/cloudera-manager.sls
+++ b/salt/cdh/cloudera-manager.sls
@@ -1,7 +1,15 @@
-{% set cm_ver = '5.9.0' %}
+{%- set cm_ver = '5.9.0' -%}
+
+{%- set mysql_root_password = salt['pillar.get']('mysql:root_pw', 'mysqldefault') -%}
+{%- set cmdb_host = salt['pnda.ip_addresses']('oozie_database')[0] -%}
+{%- set cm_host = salt['pnda.ip_addresses']('cloudera_manager')[0] -%}
+{%- set cmdb_user = salt['pillar.get']('hadoop:cmdb:user', 'scm') -%}
+{%- set cmdb_database = salt['pillar.get']('hadoop:cmdb:database', 'scm') -%}
+{%- set cmdb_password = salt['pillar.get']('hadoop:cmdb:password', 'scm') -%}
 
 include:
   - java
+  - mysql.connector
 
 cloudera-manager-add_cloudera_manager_repository:
   pkgrepo.managed:
@@ -17,11 +25,10 @@ cloudera-manager-install_cloudera_manager:
     - pkgs:
       - cloudera-manager-daemons
       - cloudera-manager-server
-      - cloudera-manager-server-db-2
 
-cloudera-manager-ensure_cloudera_manager_db_started:
-  service.running:
-    - name: cloudera-scm-server-db
+cloudera-manager-create_ext_db:
+  cmd.run:
+    - name: /usr/share/cmf/schema/scm_prepare_database.sh mysql -h {{ cmdb_host }} -uroot -p{{ mysql_root_password }} --scm-host {{ cm_host }} {{ cmdb_database }} {{ cmdb_user }} {{ cmdb_password }}
 
 cloudera-manager-ensure_cloudera_manager_started:
   service.running:

--- a/salt/cdh/cloudera-manager.sls
+++ b/salt/cdh/cloudera-manager.sls
@@ -3,9 +3,9 @@
 {%- set mysql_root_password = salt['pillar.get']('mysql:root_pw', 'mysqldefault') -%}
 {%- set cmdb_host = salt['pnda.ip_addresses']('oozie_database')[0] -%}
 {%- set cm_host = salt['pnda.ip_addresses']('cloudera_manager')[0] -%}
-{%- set cmdb_user = salt['pillar.get']('hadoop:cmdb:user', 'scm') -%}
-{%- set cmdb_database = salt['pillar.get']('hadoop:cmdb:database', 'scm') -%}
-{%- set cmdb_password = salt['pillar.get']('hadoop:cmdb:password', 'scm') -%}
+{%- set cmdb_user = salt['pillar.get']('cloudera:cmdb:user', 'scm') -%}
+{%- set cmdb_database = salt['pillar.get']('cloudera:cmdb:database', 'scm') -%}
+{%- set cmdb_password = salt['pillar.get']('cloudera:cmdb:password', 'scm') -%}
 
 include:
   - java

--- a/salt/cdh/oozie_mysql.sls
+++ b/salt/cdh/oozie_mysql.sls
@@ -134,3 +134,21 @@ cdh-Grant privileges to hue user from outside:
     - host: '%'
     - connection_user: root
     - connection_pass: {{ mysql_root_password }}
+
+cdh-Create root user remote:
+  mysql_user.present:
+    - name: root
+    - host: '%'
+    - password: {{ mysql_root_password }}
+    - connection_user: root
+    - connection_pass: {{ mysql_root_password }}
+
+cdh-Grant privileges to root user from outside:
+   mysql_grants.present:
+    - grant: all privileges
+    - grant_option: True
+    - database: '*.*'
+    - user: root
+    - host: '%'
+    - connection_user: root
+    - connection_pass: {{ mysql_root_password }}


### PR DESCRIPTION
Cloudera manager uses the external mqsql database already in use for
oozie, hue and hive instead of the embedded postgres database.

PNDA-2496