### PR TITLE
Use virtualenv for data service

### DIFF
--- a/salt/data-service/files/requirements.txt
+++ b/salt/data-service/files/requirements.txt
@@ -1,0 +1,17 @@
+cm-api==11.0.0
+happybase==0.9
+httplib2==0.9.2
+jsonschema==2.5.1
+lazy-object-proxy==1.2.1
+magicmock==0.3
+mock==1.3.0
+PyHDFS==0.1.1
+pylint==1.5.4
+simplejson==3.8.2
+tornado==4.3
+Tornado-JSON==1.2.2
+wrapt==1.10.6
+futures==3.0.5
+boto==2.40.0
+python-swiftclient==3.0.0
+python-keystoneclient==2.3.1

--- a/salt/data-service/templates/data-service.conf.tpl
+++ b/salt/data-service/templates/data-service.conf.tpl
@@ -5,6 +5,9 @@ respawn
 respawn limit unlimited
 post-stop exec sleep 2
 setuid hdfs
+
+env PYTHON_HOME={{ install_dir }}/data-service/venv
+
 chdir {{ install_dir }}/data-service
 env programDir={{ install_dir }}/data-service
-exec python ${programDir}/apiserver.py
+exec ${PYTHON_HOME}/bin/python ${programDir}/apiserver.py


### PR DESCRIPTION
We use a requirements.txt file in salt because data-service does not
ship its own.