### PR TITLE
HBase values normal size again

### DIFF
--- a/salt/cdh/templates/cfg_pico.py.tpl
+++ b/salt/cdh/templates/cfg_pico.py.tpl
@@ -318,7 +318,7 @@ HDFS_CFG = {
 HBASE_CFG = {
     "service": "HBASE",
     "name": "hbase01",
-    "config": {'hdfs_service': 'hdfs01', 'zookeeper_service': 'zk01', 'hbase_client_keyvalue_maxsize': '209715200', 'rm_dirty': 'true'},
+    "config": {'hdfs_service': 'hdfs01', 'zookeeper_service': 'zk01', 'rm_dirty': 'true'},
     "roles":
         [
             {

--- a/salt/cdh/templates/cfg_standard.py.tpl
+++ b/salt/cdh/templates/cfg_standard.py.tpl
@@ -262,7 +262,7 @@ HDFS_CFG = {
 HBASE_CFG = {
     "service": "HBASE",
     "name": "hbase01",
-    "config": {'hdfs_service': 'hdfs01', 'zookeeper_service': 'zk01', 'hbase_client_keyvalue_maxsize': '209715200'},
+    "config": {'hdfs_service': 'hdfs01', 'zookeeper_service': 'zk01'},
     "roles":
         [
             {


### PR DESCRIPTION
Now application packages are in hdfs instead of hbase the cells don't
need to allow large values anymore

PNDA-2498