### PR TITLE
Set kafka retention per flavor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Added
 - PNDA-2456: Initial work to support for Redhat 7. Salt highstate and orchestrate run on a Redhat7 HEAT cluster with no errors but requires further testing and work.
+- PNDA-2480: Added a per flavor pillar setting for kafka log retention (log.retention.bytes) set to 300MB (pico) 1GB (standard) to stop disks filling up on pico clusters.
 ### Changed
 - PNDA-2517: If Cloudera setup (cm_setup.py) fails, orchestrate can be re-run and cm_setup.py will attempt to continue from where it completed up to last time. Progress is recorded in /root/.CM_SETUP_SUCCESS which can be edited if manual control is required over the point to continue from.
 

--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -9,6 +9,9 @@
         "gobblin": {
             "max_mappers": 5
         },
+        "kafka.server": {
+            "kafka_log_retention_bytes": 314572800
+        },
         "cdh.setup_hadoop": {
             "template_file": "cfg_pico.py"
         },

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -9,6 +9,9 @@
         "gobblin": {
             "max_mappers": 50
         },
+        "kafka.server": {
+            "kafka_log_retention_bytes": 1073741824
+        },
         "cdh.setup_hadoop": {
             "template_file": "cfg_standard.py"
         },

--- a/salt/kafka/server.sls
+++ b/salt/kafka/server.sls
@@ -1,5 +1,7 @@
 {%- from 'kafka/settings.sls' import kafka, config with context %}
 
+{% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
+
 {% set pnda_cluster = salt['pnda.cluster_name']() %}
 
 {%- set kafka_zookeepers = [] -%}
@@ -33,6 +35,7 @@ kafka-server-conf:
     - template: jinja
     - context:
       zk_hosts: {{ kafka_zookeepers|join(',') }}
+      kafka_log_retention_bytes: {{ flavor_cfg.kafka_log_retention_bytes }}
 
 {% if grains['os'] == 'Ubuntu' %}
 kafka-copy_kafka_upstart:

--- a/salt/kafka/templates/server.properties.tpl
+++ b/salt/kafka/templates/server.properties.tpl
@@ -103,11 +103,11 @@ num.partitions={{ c.num_partitions }}
 # from the end of the log.
 
 # The minimum age of a log file to be eligible for deletion
-log.retention.hours=24
+#log.retention.hours=24
 
 # A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
 # segments don't drop below log.retention.bytes.
-#log.retention.bytes=1073741824
+log.retention.bytes={{ kafka_log_retention_bytes }}
 
 # The maximum size of a log segment file. When this size is reached a new log segment will be created.
 log.segment.bytes=1073741824


### PR DESCRIPTION
Set kafka retention to 300MB for pico and 1GB for standard to avoid
disks filling up on pico.

PNDA-2680