### PR TITLE
Prevent ingestion of the avro.internal.testbot topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - PNDA-2517: If Cloudera setup (cm_setup.py) fails, orchestrate can be re-run and cm_setup.py will attempt to continue from where it completed up to last time. Progress is recorded in /root/.CM_SETUP_SUCCESS which can be edited if manual control is required over the point to continue from.
 - PNDA-2672: Explicitly set CM API version number
+- PNDA-2596: Stop ingesting internal PNDA testbot topic
 
 ## [1.3.0] 2017-01-20
 ### Added

--- a/salt/gobblin/templates/mr.pull.tpl
+++ b/salt/gobblin/templates/mr.pull.tpl
@@ -45,4 +45,6 @@ metrics.reporting.file.enabled=true
 # ==== Blacklist topics ====
 # Recent Kafka version uses internal __consumer_offsets topic, which we don't
 # want to ingest
-topic.blacklist=__consumer_offsets
+# Don't ingest the avro.internal.testbot topic as it's only an internal PNDA
+# testing topic
+topic.blacklist=__consumer_offsets,avro.internal.testbot


### PR DESCRIPTION
As this is an PNDA internal test topic, it's now not visible anymore
from a user point of view.