### PR TITLE
Jupyter works on redhat

### DIFF
--- a/salt/jupyter/templates/jupyterhub.service.tpl
+++ b/salt/jupyter/templates/jupyterhub.service.tpl
@@ -3,7 +3,6 @@ Description=Jupyter Hub Daemon
 
 [Service]
 Type=simple
-User=hdfs
 WorkingDirectory={{ virtual_env_dir }}
 ExecStart={{ virtual_env_dir }}/bin/jupyterhub --config={{ jupyterhub_config_dir }}/jupyterhub_config.py
 Restart=always

--- a/salt/jupyter/templates/jupyterhub_config.py.tpl
+++ b/salt/jupyter/templates/jupyterhub_config.py.tpl
@@ -120,7 +120,7 @@
 #  
 #  This will *only* include the logs of the Hub itself, not the logs of the proxy
 #  or any single-user servers.
-#c.JupyterHub.extra_log_file = ''
+c.JupyterHub.extra_log_file = '/var/log/pnda/jupyterhub.log'
 
 ## Extra log handlers to set on JupyterHub logger
 #c.JupyterHub.extra_log_handlers = []


### PR DESCRIPTION
Run jupyterhub as root the same as on ubuntu, not sure why it was being
run as hdfs in the redhat systemd unit.

PNDA-2704