### PR TITLE
Enable services to start at boot time on redhat

### DIFF
--- a/salt/console-backend/data-manager.sls
+++ b/salt/console-backend/data-manager.sls
@@ -93,42 +93,29 @@ console-backend-install_backend_app_dependencies:
     - require:
       - npm: nodejs-update_npm
 
-{% if grains['os'] == 'Ubuntu' %}
-# Create upstart script from template
-console-backend-copy_upstart:
+# Create service script from template
+console-backend-copy_service:
   file.managed:
+{% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/data-manager.conf
     - source: salt://console-backend/templates/backend_nodejs_app.conf.tpl
-    - template: jinja
-    - defaults:
-        host_ip: {{ host_ip }}
-        backend_app_port: {{ backend_app_port }}
-        app_dir: {{ app_dir }}
 {% elif grains['os'] == 'RedHat' %}
-console-backend-dm-systemd:
-  file.managed:
     - name: /usr/lib/systemd/system/data-manager.service
     - source: salt://console-backend/templates/backend_nodejs_app.service.tpl
+{% endif %}
     - template: jinja
     - defaults:
         host_ip: {{ host_ip }}
         backend_app_port: {{ backend_app_port }}
         app_dir: {{ app_dir }}
-console-backend-dm-systemctl_reload:
-  cmd.run:
-    - name: /bin/systemctl daemon-reload
-{% endif %}
 
-# Restart the backend app if necessary
-data-manager:
-  service.running:
-    - enable: True
-    - reload: True
-    - watch:
-      - file: {{app_config_dir}}/config.js
-      - file: {{app_config_dir}}/ldap_config.js
-{% if grains['os'] == 'Ubuntu' %}
-      - file: console-backend-copy_upstart
-{% elif grains['os'] == 'RedHat' %}
-      - file: console-backend-dm-systemd
-{% endif %}
+{% if grains['os'] == 'RedHat' %}
+console-backend-data-manager-systemctl_reload:
+  cmd.run:
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable data-manager
+{%- endif %}
+
+console-backend-data-manager-start_service:
+  cmd.run:
+    - name: 'service data-manager stop || echo already stopped; service data-manager start'
+

--- a/salt/console-backend/templates/backend_nodejs_app.service.tpl
+++ b/salt/console-backend/templates/backend_nodejs_app.service.tpl
@@ -9,3 +9,6 @@ Environment=PORT={{backend_app_port}}
 ExecStart=/bin/node {{app_dir}}/app.js
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/console-frontend/init.sls
+++ b/salt/console-frontend/init.sls
@@ -113,10 +113,13 @@ console-frontend-remove_nginx_default_config:
   file.absent:
     - name: {{nginx_config_location}}/default
 
-# Reload nginx configuration
-console-frontend-reload_nginx_config:
-  service.running:
-    - name: nginx
-    - reload: True
-    - watch:
-      - file: console-frontend-create_pnda_nginx_config
+{% if grains['os'] == 'RedHat' %}
+console-frontend-systemctl_reload:
+  cmd.run:
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable nginx
+{%- endif %}
+
+console-frontend-start_service:
+  cmd.run:
+    - name: 'service nginx stop || echo already stopped; service nginx start'
+

--- a/salt/data-service/init.sls
+++ b/salt/data-service/init.sls
@@ -46,7 +46,7 @@ data-service-copy_config:
     - require:
       - archive: data-service-dl-and-extract
 
-data-service-copy_upstart:
+data-service-copy_service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/dataservice.conf
@@ -59,10 +59,13 @@ data-service-copy_upstart:
     - defaults:
         install_dir: {{ install_dir }}
 
-dataservice:
-  service.running:
-    - enable: True
-    - watch:
-      - file: data-service-copy_upstart
-      - file: data-service-create_link
+{% if grains['os'] == 'RedHat' %}
+data-service-systemctl_reload:
+  cmd.run:
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable dataservice
+{%- endif %}
+
+data-service-start_service:
+  cmd.run:
+    - name: 'service dataservice stop || echo already stopped; service dataservice start'
 

--- a/salt/data-service/templates/data-service.service.tpl
+++ b/salt/data-service/templates/data-service.service.tpl
@@ -8,3 +8,6 @@ WorkingDirectory={{ install_dir }}/data-service
 ExecStart={{ install_dir }}/data-service/venv/bin/python {{ install_dir }}/data-service/apiserver.py
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/deployment-manager/templates/deployment-manager.service.tpl
+++ b/salt/deployment-manager/templates/deployment-manager.service.tpl
@@ -7,3 +7,6 @@ WorkingDirectory={{ install_dir }}/deployment_manager
 ExecStart={{ install_dir }}/deployment_manager/venv/bin/python {{ install_dir }}/deployment_manager/app.py
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/elasticsearch/files/templates/elasticsearch.service.tpl
+++ b/salt/elasticsearch/files/templates/elasticsearch.service.tpl
@@ -7,3 +7,6 @@ LimitNOFILE=32768
 ExecStart={{ installdir }}/bin/elasticsearch -Des.default.config={{ defaultconfig }} -Des.default.path.logs={{ logdir }} -Des.default.path.data={{ datadir }} -Des.default.path.work={{ workdir }} -Des.default.path.conf={{ confdir }}
 Restart=always
 RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/elasticsearch/init.sls
+++ b/salt/elasticsearch/init.sls
@@ -75,19 +75,11 @@ elasticsearch-dl_and_extract_elasticsearch:
 /etc/init/elasticsearch.conf:
   file.managed:
     - source: salt://elasticsearch/files/templates/elasticsearch.init.conf.tpl
-    - mode: 644
-    - template: jinja
-    - context:
-      installdir: {{elasticsearch_directory}}/elasticsearch-{{ elasticsearch_version }}
-      logdir: {{elasticsearch_logdir }}
-      datadir: {{elasticsearch_datadir }}
-      confdir: {{elasticsearch_confdir }}
-      workdir: {{elasticsearch_workdir }}
-      defaultconfig: {{elasticsearch_confdir}}/elasticsearch.yml
 {% elif grains['os'] == 'RedHat' %}
 /usr/lib/systemd/system/elasticsearch.service:
   file.managed:
     - source: salt://elasticsearch/files/templates/elasticsearch.service.tpl
+{% endif %}
     - mode: 644
     - template: jinja
     - context:
@@ -97,18 +89,14 @@ elasticsearch-dl_and_extract_elasticsearch:
       confdir: {{elasticsearch_confdir }}
       workdir: {{elasticsearch_workdir }}
       defaultconfig: {{elasticsearch_confdir}}/elasticsearch.yml
+
+{% if grains['os'] == 'RedHat' %}
 elasticsearch-systemctl_reload:
   cmd.run:
-    - name: /bin/systemctl daemon-reload
-{% endif %}
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable elasticsearch
+{%- endif %}
 
-elasticsearch-service:
-  service.running:
-    - name: elasticsearch
-    - enable: true
-    - watch:
-{% if grains['os'] == 'Ubuntu' %}
-      - file: /etc/init/elasticsearch.conf
-{% elif grains['os'] == 'RedHat' %}
-      - file: /usr/lib/systemd/system/elasticsearch.service
-{% endif %}
+elasticsearch-start_service:
+  cmd.run:
+    - name: 'service elasticsearch stop || echo already stopped; service elasticsearch start'
+

--- a/salt/gobblin/init.sls
+++ b/salt/gobblin/init.sls
@@ -76,7 +76,7 @@ gobblin-install_gobblin_pnda_job_file:
     - require:
       - file: gobblin-create_gobblin_jobs_directory
 
-gobblin-install_gobblin_upstart_script:
+gobblin-install_gobblin_service_script:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/gobblin.conf
@@ -109,4 +109,4 @@ gobblin-add_gobblin_crontab_entry:
     - user: root
     - minute: 0,30
     - require:
-      - file: gobblin-install_gobblin_upstart_script
+      - file: gobblin-install_gobblin_service_script

--- a/salt/grafana/init.sls
+++ b/salt/grafana/init.sls
@@ -28,12 +28,15 @@ grafana-server_pkg:
       - grafana: {{ grafana_rpm_location }}
 {% endif %}
 
+{% if grains['os'] == 'RedHat' %}
+grafana-systemctl_reload:
+  cmd.run:
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable grafana-server
+{%- endif %}
+
 grafana-server_start:
-  service.running:
-    - name: grafana-server
-    - enable: True
-    - watch:
-      - pkg: grafana-server_pkg
+  cmd.run:
+    - name: 'service grafana-server stop || echo already stopped; service grafana-server start'
 
 grafana-login_script_run:
   cmd.script:
@@ -44,7 +47,7 @@ grafana-login_script_run:
         pnda_password: {{ pillar['pnda']['password'] }}
     - cwd: /
     - require:
-      - service: grafana-server_start
+      - cmd: grafana-server_start
 
 {% for ds in datasources %}
 grafana-create_datasources_{{ loop.index }}:

--- a/salt/hdfs-cleaner/init.sls
+++ b/salt/hdfs-cleaner/init.sls
@@ -56,7 +56,7 @@ hdfs-cleaner-copy_config:
     - require:
       - file: hdfs-cleaner-create_link
 
-hdfs-cleaner-copy_upstart:
+hdfs-cleaner-copy_service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/hdfs-cleaner.conf

--- a/salt/jmxproxy/templates/jmxproxy.service.tpl
+++ b/salt/jmxproxy/templates/jmxproxy.service.tpl
@@ -6,3 +6,6 @@ Type=simple
 ExecStart=/usr/lib/jvm/java-8-oracle/bin/java -jar {{ install_dir }}/jmxproxy.jar server {{ install_dir }}/etc/jmxproxy.yaml
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/jupyter/templates/jupyterhub.service.tpl
+++ b/salt/jupyter/templates/jupyterhub.service.tpl
@@ -7,3 +7,6 @@ WorkingDirectory={{ virtual_env_dir }}
 ExecStart={{ virtual_env_dir }}/bin/jupyterhub --config={{ jupyterhub_config_dir }}/jupyterhub_config.py
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/jupyter/templates/jupyterhub_config.py.tpl
+++ b/salt/jupyter/templates/jupyterhub_config.py.tpl
@@ -120,7 +120,7 @@
 #  
 #  This will *only* include the logs of the Hub itself, not the logs of the proxy
 #  or any single-user servers.
-c.JupyterHub.extra_log_file = '/var/log/pnda/jupyterhub.log'
+c.JupyterHub.extra_log_file = '/var/log/pnda/jupyter/jupyterhub.log'
 
 ## Extra log handlers to set on JupyterHub logger
 #c.JupyterHub.extra_log_handlers = []

--- a/salt/kafka-manager/pnda_create_cluster.sls
+++ b/salt/kafka-manager/pnda_create_cluster.sls
@@ -8,13 +8,11 @@
 {%-   do zk_servers.append(ip + ':2181') -%}
 {%- endfor -%}
 
-kafka-manager_restart-service:
-  service.running:
-    - name: kafka-manager
-    - enable: True
-    - reload: True
+pnda-create-cluster-start_service:
+  cmd.run:
+    - name: 'service kafka-manager start && sleep 10 || echo already started;'
 
-kafka-manager_create_cluster:
+pnda-create-cluster-create_cluster:
   http.query:
     - name: 'http://localhost:{{ km_port }}/clusters'
     - method: 'POST'
@@ -30,4 +28,4 @@ kafka-manager_create_cluster:
         jmxPass: ""
         activeOffsetCacheEnabled: "true"
     - require:
-      - service: kafka-manager_restart-service
+      - cmd: pnda-create-cluster-start_service

--- a/salt/kafka-manager/templates/kafka-manager.service.tpl
+++ b/salt/kafka-manager/templates/kafka-manager.service.tpl
@@ -7,3 +7,6 @@ LimitNOFILE=8192
 ExecStart=/opt/pnda/kafka-manager/bin/kafka-manager -Dconfig.file=/opt/pnda/kafka-manager/conf/application.conf -Dapplication.home=/opt/pnda/kafka-manager -Dhttp.port={{ kafka_manager_port }}
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/kafka/server.sls
+++ b/salt/kafka/server.sls
@@ -38,7 +38,7 @@ kafka-server-conf:
       kafka_log_retention_bytes: {{ flavor_cfg.kafka_log_retention_bytes }}
 
 {% if grains['os'] == 'Ubuntu' %}
-kafka-copy_kafka_upstart:
+kafka-copy_kafka_service:
   file.managed:
     - source: salt://kafka/templates/kafka.init.conf.tpl
     - name: /etc/init/kafka.conf
@@ -78,7 +78,7 @@ kafka-copy_kafka_systemd:
 
 kafka-systemctl_reload:
   cmd.run:
-    - name: /bin/systemctl daemon-reload
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable kafka
 {% endif %}
 
 kafka-logs-configuration-dirs:
@@ -99,14 +99,6 @@ kafka-logs-configuration:
     - pattern: '(\${kafka.logs.dir})'
     - repl: '/var/log/pnda/kafka'
 
-kafka-service:
-  service.running:
-    - name: kafka
-    - enable: true
-    - watch:
-      - file: kafka-server-conf
-{% if grains['os'] == 'Ubuntu' %}
-      - file: kafka-copy_kafka_upstart
-{% elif grains['os'] == 'RedHat' %}
-      - file: kafka-copy_kafka_systemd
-{% endif %}
+kafka-start_service:
+  cmd.run:
+    - name: 'service kafka stop || echo already stopped; service kafka start'

--- a/salt/kafka/templates/kafka.service.tpl
+++ b/salt/kafka/templates/kafka.service.tpl
@@ -9,3 +9,6 @@ ExecStartPre=/bin/sleep 5
 ExecStart={{ workdir }}/kafka-start-script.sh
 Restart=always
 RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/kibana/kibana-dashboard.sls
+++ b/salt/kibana/kibana-dashboard.sls
@@ -1,3 +1,7 @@
-kibana-dashboards-configure:
+kibana-dashboard-running:
+  service.running:
+    - name: kibana
+
+kibana-dashboard-configure:
   cmd.script:
     - source: salt://kibana/files/configure-dashboard.sh

--- a/salt/kibana/templates/kibana.service.tpl
+++ b/salt/kibana/templates/kibana.service.tpl
@@ -7,3 +7,6 @@ LimitNOFILE=32768
 ExecStart={{ installdir }}/bin/kibana
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/logserver/logserver.sls
+++ b/salt/logserver/logserver.sls
@@ -82,7 +82,7 @@ logserver-create_log_folder:
     - mode: 777
     - makedirs: True
 
-logserver-copy_upstart:
+logserver-copy_service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/logserver.conf
@@ -98,17 +98,17 @@ logserver-copy_upstart:
 {% if grains['os'] == 'RedHat' %}
 logserver-systemctl_reload:
   cmd.run:
-    - name: /bin/systemctl daemon-reload
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable logserver
 {%- endif %}
 
 logserver-start_service:
   cmd.run:
-    - name: 'service logserver restart'
+    - name: 'service logserver stop || echo already stopped; service logserver start'
 
-redis-start_service:
+logserver-redis-start_service:
   cmd.run:
 {% if grains['os'] == 'Ubuntu' %}
-    - name: 'service redis-server restart'
+    - name: 'service logserver stop || echo already stopped; service logserver start'
 {% elif grains['os'] == 'RedHat' %}
-    - name: 'service redis restart'
+    - name: 'service redis stop || echo already stopped; service redis start'
 {% endif %}

--- a/salt/logserver/logserver_templates/logstash.service.tpl
+++ b/salt/logserver/logserver_templates/logstash.service.tpl
@@ -6,3 +6,6 @@ Type=simple
 ExecStart={{ install_dir }}/logstash/bin/logstash -f {{ install_dir }}/logstash/collector.conf
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/logserver/logshipper.sls
+++ b/salt/logserver/logshipper.sls
@@ -74,7 +74,7 @@ logshipper-create_sincedb_folder:
     - mode: 777
     - makedirs: True
 
-logshipper-copy_upstart:
+logshipper-copy_service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/logshipper.conf
@@ -90,9 +90,9 @@ logshipper-copy_upstart:
 {% if grains['os'] == 'RedHat' %}
 logshipper-systemctl_reload:
   cmd.run:
-    - name: /bin/systemctl daemon-reload
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable logshipper
 {%- endif %}
 
 logshipper-start_service:
   cmd.run:
-    - name: 'service logshipper restart'
+    - name: 'service logshipper stop || echo already stopped; service logshipper start'

--- a/salt/logserver/logshipper_templates/logstash.service.tpl
+++ b/salt/logserver/logshipper_templates/logstash.service.tpl
@@ -6,3 +6,6 @@ Type=simple
 ExecStart={{ install_dir }}/logstash/bin/logstash -f {{ install_dir }}/logstash/shipper.conf
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/mysql/init.sls
+++ b/salt/mysql/init.sls
@@ -70,21 +70,18 @@ mysql-update-mysql-configuration2:
     - require:
       - pkg: mysql-install-mysql-server
 
+{% if grains['os'] == 'RedHat' %}
+mysql-systemctl_reload:
+  cmd.run:
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable mysqld
+{%- endif %}
+
 mysql-mysql-running:
-  service.running:
+  cmd.run:
 {% if grains['os'] == 'Ubuntu' %}
-    - name: mysql
+    - name: 'service mysql stop || echo already stopped; service mysql start'
 {% elif grains['os'] == 'RedHat' %}
-    - name: mysqld
-    - enable: True
-    - reload: True
-{% endif %}
-    - watch:
-      - pkg: mysql-install-mysql-server
-{% if grains['os'] == 'Ubuntu' %}
-      - file: /etc/mysql/my.cnf
-{% elif grains['os'] == 'RedHat' %}
-      - file: /etc/my.cnf
+    - name: 'service mysqld stop || echo already stopped; service mysqld start'
 {% endif %}
 
 {% if grains['os'] == 'RedHat' %}

--- a/salt/nginx/init.sls
+++ b/salt/nginx/init.sls
@@ -7,11 +7,13 @@ nginx_conf_file:
     - name: /etc/nginx/nginx.conf
     - source: salt://nginx/files/nginx.conf
 {% endif %}
-nginx-service:
-  service.running:
-    - name: nginx
-    - enable: True
+
 {% if grains['os'] == 'RedHat' %}
-    - watch:
-      - file: nginx_conf_file
-{% endif %}
+nginx-systemctl_reload:
+  cmd.run:
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable nginx
+{%- endif %}
+
+nginx-start_service:
+  cmd.run:
+    - name: 'service nginx stop || echo already stopped; service nginx start'

--- a/salt/ntp/init.sls
+++ b/salt/ntp/init.sls
@@ -12,13 +12,10 @@ ntp-install_conf:
     - context:
       ntp_servers: {{ ntp_servers }}
 
-ntp-service-running:
-  service.running:
+ntp-start_service:
+  cmd.run:
     {% if grains['os'] == 'RedHat' %}
-    - name: ntpd
+    - name: 'service ntpd stop || echo already stopped; service ntpd start'
     {% elif grains['os'] == 'Ubuntu' %}
-    - name: ntp
+    - name: 'service ntp stop || echo already stopped; service ntp start'
     {% endif %}
-    - enable: true
-    - watch:
-      - file: ntp-install_conf

--- a/salt/opentsdb/files/opentsdb.default
+++ b/salt/opentsdb/files/opentsdb.default
@@ -1,0 +1,1 @@
+JAVA_HOME=/usr/lib/jvm/java-8-oracle

--- a/salt/opentsdb/templates/opentsdb.service.tpl
+++ b/salt/opentsdb/templates/opentsdb.service.tpl
@@ -6,3 +6,6 @@ Type=simple
 ExecStart=/usr/bin/tsdb tsd
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/package-repository/templates/package-repository.service.tpl
+++ b/salt/package-repository/templates/package-repository.service.tpl
@@ -7,3 +7,6 @@ WorkingDirectory={{ install_dir }}/package_repository
 ExecStart={{ install_dir }}/package_repository/venv/bin/python {{ install_dir }}/package_repository/package_repository_rest_server.py
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/platform-testing/cdh.sls
+++ b/salt/platform-testing/cdh.sls
@@ -59,7 +59,7 @@ platform-testing-cdh-install-requirements-cdh:
     - require:
       - virtualenv: platform-testing-cdh-create-venv
 
-platform-testing-cdh_upstart:
+platform-testing-cdh_service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-cdh.conf.tpl
@@ -90,7 +90,7 @@ platform-testing-cdh-crontab-cdh:
 {% endif %}
     - require:
       - pip: platform-testing-cdh-install-requirements-cdh
-      - file: platform-testing-cdh_upstart
+      - file: platform-testing-cdh_service
 
 platform-testing-cdh-install-requirements-cdh_blackbox:
   pip.installed:
@@ -99,7 +99,7 @@ platform-testing-cdh-install-requirements-cdh_blackbox:
     - require:
       - virtualenv: platform-testing-cdh-create-venv
 
-platform-testing-cdh-blackbox_upstart:
+platform-testing-cdh-blackbox_service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-cdh-blackbox.conf.tpl
@@ -130,7 +130,7 @@ platform-testing-cdh-crontab-cdh_blackbox:
 {% endif %}
     - require:
       - pip: platform-testing-cdh-install-requirements-cdh_blackbox
-      - file: platform-testing-cdh-blackbox_upstart
+      - file: platform-testing-cdh-blackbox_service
 
 {% if grains['os'] == 'RedHat' %}
 platform-testing-cdh-systemctl_reload:

--- a/salt/platform-testing/general.sls
+++ b/salt/platform-testing/general.sls
@@ -82,7 +82,7 @@ platform-testing-general-install-requirements-kafka:
     - require:
       - virtualenv: platform-testing-general-create-venv
 
-platform-testing-general-kafka_upstart:
+platform-testing-general-kafka_service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-general-kafka.conf.tpl
@@ -117,7 +117,7 @@ platform-testing-general-install-requirements-zookeeper:
     - require:
       - virtualenv: platform-testing-general-create-venv
 
-platform-testing-general-zookeeper-upstart:
+platform-testing-general-zookeeper-service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-general-zookeeper.conf.tpl
@@ -152,7 +152,7 @@ platform-testing-general-install-requirements-dm-blackbox:
     - require:
       - virtualenv: platform-testing-general-create-venv
 
-platform-testing-general-dm-blackbox_upstart:
+platform-testing-general-dm-blackbox_service:
   file.managed:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-general-dm-blackbox.conf.tpl

--- a/salt/reboot/install_restart.sls
+++ b/salt/reboot/install_restart.sls
@@ -28,7 +28,7 @@ reboot-copy_config:
       - virtualenv: reboot-create-venv
 
 {% if grains['os'] == 'Ubuntu' %}
-reboot-copy_upstart:
+reboot-copy_service:
   file.managed:
     - name: /etc/init/pnda-restart.conf
     - source: salt://reboot/templates/pnda-restart.conf.tpl

--- a/salt/reboot/restart_services.sls
+++ b/salt/reboot/restart_services.sls
@@ -1,6 +1,6 @@
 include:
   - reboot.install_restart
 
-restart-start:
-  service.running:
-    - name: pnda-restart
+restart-start_service:
+  cmd.run:
+    - name: 'service pnda-restart stop || echo already stopped; service pnda-restart start'

--- a/salt/zookeeper/files/templates/zookeeper.service.tpl
+++ b/salt/zookeeper/files/templates/zookeeper.service.tpl
@@ -10,3 +10,6 @@ ExecStartPre={{ conf_dir }}/../bin/zookeeper-service-startpre.sh
 ExecStart={{ conf_dir }}/../bin/zookeeper-service-start.sh
 Restart=always
 RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/zookeeper/init.sls
+++ b/salt/zookeeper/init.sls
@@ -89,7 +89,7 @@ zookeeper-link:
       - archive: zookeeper-dl-and-extract
 
 {% if grains['os'] == 'Ubuntu' %}
-zookeeper-upstart:
+zookeeper-service:
   file.managed:
     - name: /etc/init/zookeeper.conf
     - source: salt://zookeeper/files/templates/zookeeper.init.conf.tpl
@@ -132,22 +132,14 @@ zookeeper-systemd:
     - mode: 644
     - require:
       - file: zookeeper-data-dir
-zookeeper-systemctl_reload:
-  cmd.run:
-    - name: /bin/systemctl daemon-reload
 {% endif %}
 
+{% if grains['os'] == 'RedHat' %}
+zookeeper-systemctl_reload:
+  cmd.run:
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable zookeeper
+{%- endif %}
+
 zookeeper-ensure-service-running:
-  service.running:
-    - name: zookeeper
-    - watch:
-      - archive: zookeeper-dl-and-extract
-      - file: zookeeper-environment
-      - file: zookeeper-configuration
-      - file: zookeeper-myid
-{% if grains['os'] == 'Ubuntu' %}
-      - file: zookeeper-upstart
-{% elif grains['os'] == 'RedHat' %}
-      - file: zookeeper-systemd
-{% endif %}
-      - file: zookeeper-link
+  cmd.run:
+    - name: 'service zookeeper stop || echo already stopped; service zookeeper start'


### PR DESCRIPTION
Replace service.running with cmd.run 'service restart' at the end of each sls. This ensures the service always restarts when the sls is run to load updated config.

Simpler and more reliable to restart services at the end of the sls instead of using service.running with watch statements that are complicated, platform dependent and often incomplete.

PNDA-2734