### PR TITLE
Move jmxproxy in its own directory

### DIFF
--- a/salt/jmxproxy/init.sls
+++ b/salt/jmxproxy/init.sls
@@ -8,7 +8,7 @@
 
 {% set jmxproxy_url = mirror_location + jmxproxy_jar %}
 
-{% set install_dir = pillar['pnda']['homedir'] %}
+{% set install_dir = pillar['pnda']['homedir'] + '/jmxproxy' %}
 
 
 jmxproxy-create_release_dir:


### PR DESCRIPTION
It prevents salt from changing ownership of /opt/pnda to root.