### PR TITLE
Change the mode of my-id file to match the tree mode state.

### DIFF
--- a/salt/zookeeper/init.sls
+++ b/salt/zookeeper/init.sls
@@ -59,7 +59,7 @@ zookeeper-myid:
           ip: {{ node.ip }}
           fqdn: {{ node.fqdn }}
       {%- endfor %}
-    - mode: 644
+    - mode: 755
     - require:
       - file: zookeeper-data-dir
 


### PR DESCRIPTION
Having the zookeeper-data-dir state setting the mode differently then
the subfile in the tree causes the state of my-id to change. This state
change causes the service to restart unnecessarily.