### PR TITLE
PNDA-2832- Jupyter %sql magic support.

### DIFF
--- a/salt/jupyter/files/requirements-jupyter.txt
+++ b/salt/jupyter/files/requirements-jupyter.txt
@@ -6,6 +6,7 @@ html5lib==0.9999999
 ipykernel==4.5.2
 ipython==5.1.0
 ipython-genutils==0.1.0
+ipython-sql==0.3.8
 Jinja2==2.8
 jsonschema==2.5.1
 jupyter==1.0.0
@@ -27,6 +28,7 @@ pyzmq==16.0.2
 qtconsole==4.2.1
 simplegeneric==0.8.1
 six==1.10.0
+sql-magic==0.0.3
 terminado==0.6
 testpath==0.3
 tornado==4.4.2

--- a/salt/jupyter/jupyter_deps.sls
+++ b/salt/jupyter/jupyter_deps.sls
@@ -8,4 +8,4 @@
 
 jupyter-install_anaconda_deps:
   cmd.run:
-    - name: export PATH={{ anaconda_home }}/bin:$PATH;pip install --index-url {{ pip_index_url }} cm-api==14.0.0 avro==1.8.1
+    - name: export PATH={{ anaconda_home }}/bin:$PATH;pip install --index-url {{ pip_index_url }} cm-api==14.0.0 avro==1.8.1 ipython-sql==0.3.8 sql-magic==0.0.3


### PR DESCRIPTION
%sql is spark-sql magic of ipython kernel, which allows users to load data from relational database and impala using SQL as spark data-frames or pandas dataframes.
now sql magic is supported in all the three kernels, namely -

python3
python2 Anaconda
python pyspark