### PR TITLE
Remove asterisk from spark-examples.jar

### DIFF
--- a/salt/jupyter/templates/pyspark_kernel.json.tpl
+++ b/salt/jupyter/templates/pyspark_kernel.json.tpl
@@ -14,6 +14,6 @@
   "SPARK_HOME": "{{ spark_home }}",
   "PYTHONPATH": "{{ spark_home }}/python:{{ spark_home }}/python/lib/py4j-0.9-src.zip",
   "PYTHONSTARTUP": "{{ spark_home }}/python/pyspark/shell.py",
-  "PYSPARK_SUBMIT_ARGS": "--master yarn-client --jars {{ spark_home }}/lib/spark-examples*.jar pyspark-shell"
+  "PYSPARK_SUBMIT_ARGS": "--master yarn-client --jars {{ spark_home }}/lib/spark-examples.jar pyspark-shell"
  }
 }


### PR DESCRIPTION
Remove asterisk from spark-examples.jar in PYSPARK_SUBMIT_ARGS in pyspark_kernel.json.tpl

PNDA-3233