### PR TITLE
Fix openssl version at 1.0.1

### DIFF
--- a/pillar/packages/RedHat.sls
+++ b/pillar/packages/RedHat.sls
@@ -44,7 +44,7 @@ grafana:
   package-source: 'grafana-4.2.0-1.x86_64.rpm'
 libssl-dev:
   package-name: openssl-devel
-  version: ""
+  version: "1.0.1e-60.el7"
 libffi-dev:
   package-name: libffi-devel
   version:  ""


### PR DESCRIPTION
openssl 1.0.2 leaves ambari agents unable to connect to the server.

PNDA-3247