### PR TITLE
Add CentOS support

### DIFF
--- a/pillar/packages/CentOS.sls
+++ b/pillar/packages/CentOS.sls
@@ -1,0 +1,104 @@
+acl:
+  package-name: acl
+  version: ""
+ambari-agent:
+  package-name: ambari-agent
+  version: "2.5.1.0-159"
+ambari-server:
+  package-name: ambari-server
+  version: "2.5.1.0-159"
+at:
+  package-name: at
+  version: ""
+bzip2:
+  package-name: bzip2
+  version: ""
+cloudera-manager-agent:
+  package-name: cloudera-manager-agent
+  version: "5.9.0-1.cm590.p0.249.el7"
+cloudera-manager-daemons:
+  package-name: cloudera-manager-daemons
+  version: "5.9.0-1.cm590.p0.249.el7"
+cloudera-manager-server:
+  package-name: cloudera-manager-server
+  version: "5.9.0-1.cm590.p0.249.el7"
+cyrus-sasl-devel:
+  package-name: cyrus-sasl-devel
+  version: ""
+cyrus-sasl-gssapi:
+  package-name: cyrus-sasl-gssapi
+  version: ""
+cyrus-sasl-plain:
+  package-name: cyrus-sasl-plain
+  version: ""
+g++:
+  package-name: gcc-c++
+  version: ""
+glibc-devel:
+  package-name: glibc-devel
+  version: ""
+gnuplot:
+  package-name: gnuplot
+  version: ""
+grafana:
+  package-source: 'grafana-4.2.0-1.x86_64.rpm'
+libssl-dev:
+  package-name: openssl-devel
+  version: ""
+libffi-dev:
+  package-name: libffi-devel
+  version:  ""
+libtirpc-devel:
+  package-name: libtirpc-devel
+  version:  ""
+libsasl:
+  package-name: libgsasl-devel
+  version: ""
+mysql-server:
+  package-name: mysql-community-server
+  version: "5.5.54-2.el7"
+  configuration_file: /etc/my.cnf
+  service_name: mysqld
+nginx:
+  package-name: nginx
+  version: ""
+nmap-ncat:
+  package-name: nmap-ncat
+  version: ""
+ntp:
+  package-name: ntp
+  version: ""
+opentsdb:
+  package-source: 'opentsdb-2.3.0.rpm'
+  bind_port: 4242
+python-pip:
+  package-name: python2-pip
+  version: ""
+python-dev:
+  package-name: python-devel
+  version: ""
+python3-pip:
+  package-name: python34-pip
+  version: ""
+python3-dev:
+  package-name: python34-devel
+  version: ""
+python-mysqldb:
+  package-name: MySQL-python
+  version: "1.2.5-1.el7"
+redis-server:
+  package-name: redis
+  version: "3.2.3-1.el7"
+  configuration_filename: "/etc/redis.conf"
+snappy:
+  package-name: snappy-devel
+  version: ""
+sshfs:
+  package-name: fuse-sshfs
+  version: ""
+unzip:
+  package-name: unzip
+  version: ""
+wget:
+  package-name: wget
+  version: ""

--- a/salt/ambari/agent.sls
+++ b/salt/ambari/agent.sls
@@ -6,7 +6,7 @@ ambari-agent-user:
     - groups:
       - root
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 ambari-agent-libtirpc:
   pkg.installed:
     - name: {{ pillar['libtirpc-devel']['package-name'] }}
@@ -34,7 +34,7 @@ ambari-agent-create_log_dir:
     - name: /var/log/pnda/ambari/
     - makedirs: True
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 ambari-agent-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable ambari-agent

--- a/salt/ambari/server.sls
+++ b/salt/ambari/server.sls
@@ -47,7 +47,7 @@ ambari-server-jdbc-dl:
     - source: {{ mirror_location }}/{{ jdbc_package }}
     - source_hash: {{ mirror_location }}/{{ jdbc_package }}.sha512.txt
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 ambari-server-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable ambari-server

--- a/salt/anaconda/init.sls
+++ b/salt/anaconda/init.sls
@@ -4,7 +4,7 @@
 {% set anaconda_parcel_version = pillar['anaconda']['parcel_version'] %}
 {% set anaconda_package = 'Anaconda2-' + anaconda_parcel_version + '-Linux-x86_64.sh' %}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 anaconda-deps:
   pkg.installed:
     - name: {{ pillar['bzip2']['package-name'] }}

--- a/salt/cdh/cloudera-manager.sls
+++ b/salt/cdh/cloudera-manager.sls
@@ -22,7 +22,7 @@ cloudera-manager-install_server:
     - name: {{ pillar['cloudera-manager-server']['package-name'] }}
     - version: {{ pillar['cloudera-manager-server']['version'] }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 cloudera-manager-ensure_cloudera_manager_enabled:
   cmd.run:
     - name: /bin/systemctl enable cloudera-scm-server

--- a/salt/console-backend/data-logger.sls
+++ b/salt/console-backend/data-logger.sls
@@ -59,7 +59,7 @@ console-backend-copy_data_logger_service:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/data-logger.conf
     - source: salt://console-backend/templates/backend_nodejs_app.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/data-logger.service
     - source: salt://console-backend/templates/backend_nodejs_app.service.tpl
 {% endif %}
@@ -70,7 +70,7 @@ console-backend-copy_data_logger_service:
         backend_app_port: {{ backend_app_port }}
         app_dir: {{ app_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 console-backend-data-logger-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable data-logger; /bin/systemctl enable redis
@@ -80,7 +80,7 @@ console-backend-redis_start:
   cmd.run:
 {% if grains['os'] == 'Ubuntu' %}
     - name: 'service redis-server stop || echo already stopped; service redis-server start'
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: 'service redis stop || echo already stopped; service redis start'
 {% endif %}
 

--- a/salt/console-backend/data-manager.sls
+++ b/salt/console-backend/data-manager.sls
@@ -90,7 +90,7 @@ console-backend-copy_service:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/data-manager.conf
     - source: salt://console-backend/templates/backend_nodejs_app.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/data-manager.service
     - source: salt://console-backend/templates/backend_nodejs_app.service.tpl
 {% endif %}
@@ -100,7 +100,7 @@ console-backend-copy_service:
         backend_app_port: {{ backend_app_port }}
         app_dir: {{ app_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 console-backend-data-manager-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable data-manager

--- a/salt/console-frontend/init.sls
+++ b/salt/console-frontend/init.sls
@@ -3,7 +3,7 @@
 {% set console_frontend_package = 'console-frontend-' + console_frontend_version + '.tar.gz' %}
 {% if grains['os'] == 'Ubuntu' %}
 {% set nginx_config_location = '/etc/nginx/sites-enabled' %}
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 {% set nginx_config_location = '/etc/nginx/conf.d' %}
 {% endif %}
 {% set install_dir = pillar['pnda']['homedir'] %}
@@ -56,7 +56,7 @@ console-frontend-dl-and-extract:
     - user: root
 {% if grains['os'] == 'Ubuntu' %}
     - group: www-data
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - group: nginx
 {% endif %}
     - archive_format: tar
@@ -128,7 +128,7 @@ console-frontend-remove_nginx_default_config:
   file.absent:
     - name: {{nginx_config_location}}/default
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 console-frontend-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable nginx

--- a/salt/data-service/init.sls
+++ b/salt/data-service/init.sls
@@ -55,7 +55,7 @@ data-service-copy_service:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/dataservice.conf
     - source: salt://data-service/templates/data-service.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/dataservice.service
     - source: salt://data-service/templates/data-service.service.tpl
 {%- endif %}
@@ -63,7 +63,7 @@ data-service-copy_service:
     - defaults:
         install_dir: {{ install_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 data-service-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable dataservice

--- a/salt/deployment-manager/init.sls
+++ b/salt/deployment-manager/init.sls
@@ -10,7 +10,7 @@
 include:
   - python-pip
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 deployment-manager-install_dev_deps_cyrus:
   pkg.installed:
     - name: {{ pillar['cyrus-sasl-devel']['package-name'] }}
@@ -106,7 +106,7 @@ deployment-manager-copy_service:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/deployment-manager.conf
     - source: salt://deployment-manager/templates/deployment-manager.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/deployment-manager.service
     - source: salt://deployment-manager/templates/deployment-manager.service.tpl
 {% endif %}    
@@ -114,7 +114,7 @@ deployment-manager-copy_service:
     - defaults:
         install_dir: {{ install_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 deployment-manager-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable deployment-manager

--- a/salt/elasticsearch-cluster/init.sls
+++ b/salt/elasticsearch-cluster/init.sls
@@ -111,7 +111,7 @@ elasticsearch-copy_configuration_elasticsearch:
 /etc/init/elasticsearch.conf:
   file.managed:
     - source: salt://elasticsearch-cluster/templates/elasticsearch.init.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 /usr/lib/systemd/system/elasticsearch.service:
   file.managed:
     - source: salt://elasticsearch-cluster/templates/elasticsearch.service.tpl
@@ -127,7 +127,7 @@ elasticsearch-copy_configuration_elasticsearch:
       workdir: {{elasticsearch_workdir }}
       defaultconfig: {{elasticsearch_confdir}}/elasticsearch.yml
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 elasticsearch-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable elasticsearch

--- a/salt/elasticsearch/init.sls
+++ b/salt/elasticsearch/init.sls
@@ -72,7 +72,7 @@ elasticsearch-dl_and_extract_elasticsearch:
 /etc/init/elasticsearch.conf:
   file.managed:
     - source: salt://elasticsearch/templates/elasticsearch.init.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 /usr/lib/systemd/system/elasticsearch.service:
   file.managed:
     - source: salt://elasticsearch/templates/elasticsearch.service.tpl
@@ -87,7 +87,7 @@ elasticsearch-dl_and_extract_elasticsearch:
       workdir: {{ es_p.workdir }}
       defaultconfig: {{ es_p.confdir }}/elasticsearch.yml
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 elasticsearch-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable elasticsearch

--- a/salt/gobblin/init.sls
+++ b/salt/gobblin/init.sls
@@ -90,7 +90,7 @@ gobblin-install_gobblin_service_script:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/gobblin.conf
     - source: salt://gobblin/templates/gobblin.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/gobblin.service
     - source: salt://gobblin/templates/gobblin.service.tpl
 {%- endif %}
@@ -102,7 +102,7 @@ gobblin-install_gobblin_service_script:
       gobblin_job_file: {{ gobblin_link_dir }}/configs/mr.pull
       hadoop_home_bin: {{ hadoop_home_bin }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 gobblin-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload
@@ -113,7 +113,7 @@ gobblin-add_gobblin_crontab_entry:
     - identifier: GOBBLIN
 {% if grains['os'] == 'Ubuntu' %}
     - name: /sbin/start gobblin
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start gobblin
 {%- endif %}
     - user: root

--- a/salt/graphite-api/init.sls
+++ b/salt/graphite-api/init.sls
@@ -41,7 +41,7 @@ graphite-api-carbon-enable-and-start:
 
 graphite-api-install-graphite:
   pkg.installed:
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
     - name: graphite-api
 {% elif grains['os'] == 'Ubuntu' %}
     - sources:
@@ -56,7 +56,7 @@ graphite-api-configure-default:
 graphite-api-configure:
   file.managed:
     - name: /etc/graphite-api.yaml
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
     - source: salt://graphite-api/files/graphite-api.yaml.redhat
 {% elif grains['os'] == 'Ubuntu' %}
     - source: salt://graphite-api/files/graphite-api.yaml.debian

--- a/salt/graphite-api/map.jinja
+++ b/salt/graphite-api/map.jinja
@@ -9,4 +9,9 @@
         'graphite_api_default': '/etc/sysconfig/graphite-api',
         'graphite_api_default_src': 'graphite-api.redhat'
     },
+    'CentOS': {
+        'carbon_package': 'python-carbon',
+        'graphite_api_default': '/etc/sysconfig/graphite-api',
+        'graphite_api_default_src': 'graphite-api.redhat'
+    },
 }, merge=salt['pillar.get']('graphite-api:lookup')) %}

--- a/salt/hdfs-cleaner/init.sls
+++ b/salt/hdfs-cleaner/init.sls
@@ -75,7 +75,7 @@ hdfs-cleaner-copy_service:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/hdfs-cleaner.conf
     - source: salt://hdfs-cleaner/templates/hdfs-cleaner.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/hdfs-cleaner.service
     - source: salt://hdfs-cleaner/templates/hdfs-cleaner.service.tpl
 {%- endif %}
@@ -83,7 +83,7 @@ hdfs-cleaner-copy_service:
     - defaults:
         install_dir: {{ install_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 hdfs-cleaner-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload
@@ -94,7 +94,7 @@ hdfs-cleaner-add_crontab_entry:
     - identifier: HDFS-CLEANER
 {% if grains['os'] == 'Ubuntu' %}
     - name: /sbin/start hdfs-cleaner
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start hdfs-cleaner
 {%- endif %}
     - user: root

--- a/salt/jmxproxy/init.sls
+++ b/salt/jmxproxy/init.sls
@@ -48,7 +48,7 @@ jmxproxy-service_script:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/jmxproxy.conf
     - source: salt://{{ sls }}/templates/jmxproxy.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/jmxproxy.service
     - source: salt://{{ sls }}/templates/jmxproxy.service.tpl
 {% endif %}
@@ -57,7 +57,7 @@ jmxproxy-service_script:
     - defaults:
         install_dir: {{ install_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 jmxproxy-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable jmxproxy

--- a/salt/jupyter/jupyterhub.sls
+++ b/salt/jupyter/jupyterhub.sls
@@ -68,7 +68,7 @@ jupyterhub-copy_service:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://jupyter/templates/jupyterhub.conf.tpl
     - name: /etc/init/jupyterhub.conf
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/jupyterhub.service
     - source: salt://jupyter/templates/jupyterhub.service.tpl
 {%- endif %}
@@ -78,7 +78,7 @@ jupyterhub-copy_service:
       jupyterhub_config_dir: {{ jupyterhub_config_dir }}
       virtual_env_dir: {{ virtual_env_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 jupyterhub-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable jupyterhub

--- a/salt/kafka-manager/init.sls
+++ b/salt/kafka-manager/init.sls
@@ -48,7 +48,7 @@ kafka-manager-install-kafka-manager-service-script:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/kafka-manager.conf
     - source: salt://kafka-manager/templates/kafka-manager.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/kafka-manager.service
     - source: salt://kafka-manager/templates/kafka-manager.service.tpl
 {% endif %}
@@ -61,7 +61,7 @@ kafka-manager-update-kafka-manager:
     - name: {{ release_directory }}/kafka-manager-{{ release_version }}/bin/kafka-manager
     - mode: 755
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 kafka-manager-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable kafka-manager

--- a/salt/kafka/server.sls
+++ b/salt/kafka/server.sls
@@ -48,7 +48,7 @@ kafka-copy_kafka_service:
       workdir: {{ kafka.prefix }}
       mem_xmx: {{ mem_xmx }}
       mem_xms: {{ mem_xmx }}
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 kafka-copy_script:
   file.managed:
     - source: salt://kafka/templates/kafka-start.sh.tpl

--- a/salt/kibana/init.sls
+++ b/salt/kibana/init.sls
@@ -40,7 +40,7 @@ kibana-copy_kibana_service:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://kibana/templates/kibana.init.conf.tpl
     - name: /etc/init/kibana.conf
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - source: salt://kibana/templates/kibana.service.tpl
     - name: /usr/lib/systemd/system/kibana.service
 {% endif %}
@@ -49,7 +49,7 @@ kibana-copy_kibana_service:
     - context:
       installdir: {{ kibana_directory }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 kibana-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable kibana

--- a/salt/logserver/logserver.sls
+++ b/salt/logserver/logserver.sls
@@ -75,7 +75,7 @@ logserver-create_log_folder:
     - user: root
 {% if grains['os'] == 'Ubuntu' %}
     - group: syslog
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - group: root
 {% endif %}
     - mode: 777
@@ -86,7 +86,7 @@ logserver-copy_service:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/logserver.conf
     - source: salt://logserver/logserver_templates/logstash.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/logserver.service
     - source: salt://logserver/logserver_templates/logstash.service.tpl
 {% endif %}
@@ -94,7 +94,7 @@ logserver-copy_service:
     - defaults:
         install_dir: {{ install_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 logserver-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable logserver
@@ -108,6 +108,6 @@ logserver-redis-start_service:
   cmd.run:
 {% if grains['os'] == 'Ubuntu' %}
     - name: 'service redis-server stop || echo already stopped; service redis-server start'
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: 'service redis stop || echo already stopped; service redis start'
 {% endif %}

--- a/salt/logserver/logshipper.sls
+++ b/salt/logserver/logshipper.sls
@@ -40,7 +40,7 @@ logshipper-link_release:
     - cwd: {{ install_dir }}
     - unless: test -L {{ install_dir }}/logstash
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 logshipper-journald-plugin:
   cmd.run:
     - name: curl {{ plugin_pack_url }} > {{ install_dir }}/logstash/{{ plugin_pack_name }}; cd {{ install_dir }}/logstash; bin/logstash-plugin install file://{{ install_dir }}/logstash/{{ plugin_pack_name }};
@@ -94,7 +94,7 @@ logshipper-copy_service:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/logshipper.conf
     - source: salt://logserver/logshipper_templates/logstash.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/logshipper.service
     - source: salt://logserver/logshipper_templates/logstash.service.tpl
 {% endif %}
@@ -102,7 +102,7 @@ logshipper-copy_service:
     - defaults:
         install_dir: {{ install_dir }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 logshipper-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable logshipper

--- a/salt/logserver/logshipper_templates/shipper.conf.tpl
+++ b/salt/logserver/logshipper_templates/shipper.conf.tpl
@@ -1,6 +1,6 @@
 {%- set logdest = salt['pnda.ip_addresses']('logserver')[0] -%}
 input {
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
    journald {
           path => '/run/log/journal'
           sincedb_path => "/opt/pnda/logstash/sincedb/db2"

--- a/salt/logstash/init.sls
+++ b/salt/logstash/init.sls
@@ -91,7 +91,7 @@ logstash-copy_configuration_logstash:
 /etc/init/logstash.conf:
   file.managed:
     - source: salt://logstash/templates/logstash.init.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 /usr/lib/systemd/system/logstash.service:
   file.managed:
     - source: salt://logstash/templates/logstash.service.tpl  
@@ -104,7 +104,7 @@ logstash-copy_configuration_logstash:
       confpath: {{logstash_confdir }}/logstash.conf
       datadir: {{logstash_datadir}}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 logstash-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable logstash

--- a/salt/mysql/connector.sls
+++ b/salt/mysql/connector.sls
@@ -11,7 +11,7 @@ mysql-connector-install-java-library:
     - name: {{ pillar['libmysql-java']['package-name'] }}
     - version: {{ pillar['libmysql-java']['version'] }}
     - ignore_epoch: True
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 mysql-connector-create-dir:
   file.directory:
     - name: '/usr/share/java'

--- a/salt/mysql/init.sls
+++ b/salt/mysql/init.sls
@@ -52,7 +52,7 @@ mysql-update-mysql-configuration2:
     - require:
       - pkg: mysql-install-mysql-server
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 mysql-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable {{ pillar['mysql-server']['service_name'] }}
@@ -62,7 +62,7 @@ mysql-mysql-running:
   cmd.run:
     - name: 'service {{ pillar['mysql-server']['service_name'] }} stop || echo already stopped; service {{ pillar['mysql-server']['service_name'] }} start'
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 mysql_root_password:
   cmd.run:
     - name: mysqladmin --user root password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'

--- a/salt/nginx/init.sls
+++ b/salt/nginx/init.sls
@@ -4,14 +4,14 @@ nginx-pkg:
     - version: {{ pillar['nginx']['version'] }}
     - ignore_epoch: True
     
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 nginx_conf_file:
   file.managed:
     - name: /etc/nginx/nginx.conf
     - source: salt://nginx/files/nginx.conf
 {% endif %}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 nginx-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable nginx

--- a/salt/ntp/init.sls
+++ b/salt/ntp/init.sls
@@ -21,7 +21,7 @@ ntp-install_conf:
 
 ntp-start_service:
   cmd.run:
-    {% if grains['os'] == 'RedHat' %}
+    {% if grains['os'] in ('RedHat', 'CentOS') %}
     - name: 'service ntpd stop || echo already stopped; service ntpd start'
     {% elif grains['os'] == 'Ubuntu' %}
     - name: 'service ntp stop || echo already stopped; service ntp start'

--- a/salt/opentsdb/init.sls
+++ b/salt/opentsdb/init.sls
@@ -16,7 +16,7 @@ opentsdb-copy_defaults:
   file.managed:
     - name: /etc/default/opentsdb
     - source: salt://opentsdb/files/opentsdb.default
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 opentsdb-copy_service:
   file.managed:
     - name: /usr/lib/systemd/system/opentsdb.service
@@ -24,7 +24,7 @@ opentsdb-copy_service:
     - template: jinja
 {%- endif %}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 opentsdb-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable opentsdb

--- a/salt/package-repository/init.sls
+++ b/salt/package-repository/init.sls
@@ -55,7 +55,7 @@ package-repository-copy_service:
 {% if grains['os'] == 'Ubuntu' %}
     - name: /etc/init/package-repository.conf
     - source: salt://package-repository/templates/package-repository.conf.tpl
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/package-repository.service
     - source: salt://package-repository/templates/package-repository.service.tpl
 {% endif %}    
@@ -75,7 +75,7 @@ package-repository-create_fs_location_path:
 
 {% endif %}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 package-repository-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable package-repository

--- a/salt/platform-testing/cdh.sls
+++ b/salt/platform-testing/cdh.sls
@@ -37,7 +37,7 @@ platform-testing-cdh-dl-and-extract:
     - tar_options: v
     - if_missing: {{ platform_testing_directory }}/{{ platform_testing_package }}-{{ platform_testing_version }}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 platform-testing-cdh-install_dev_deps_cyrus:
   pkg.installed:
     - name: {{ pillar['cyrus-sasl-devel']['package-name'] }}
@@ -98,7 +98,7 @@ platform-testing-cdh_service:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-{{ platform_testing_service }}.conf.tpl
     - name: /etc/init/platform-testing-cdh.conf
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - source: salt://platform-testing/templates/platform-testing-{{ platform_testing_service }}.service.tpl
     - name: /usr/lib/systemd/system/platform-testing-cdh.service
 {% endif %}
@@ -120,7 +120,7 @@ platform-testing-cdh-crontab-cdh:
     - user: root
 {% if grains['os'] == 'Ubuntu' %}
     - name: /sbin/start platform-testing-cdh
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-cdh
 {% endif %}
     - require:
@@ -140,7 +140,7 @@ platform-testing-cdh-blackbox_service:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-cdh-blackbox.conf.tpl
     - name: /etc/init/platform-testing-cdh-blackbox.conf
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - source: salt://platform-testing/templates/platform-testing-cdh-blackbox.service.tpl
     - name: /usr/lib/systemd/system/platform-testing-cdh-blackbox.service
 {% endif %}
@@ -162,14 +162,14 @@ platform-testing-cdh-crontab-cdh_blackbox:
     - user: root
 {% if grains['os'] == 'Ubuntu' %}
     - name: /sbin/start platform-testing-cdh-blackbox
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-cdh-blackbox
 {% endif %}
     - require:
       - pip: platform-testing-cdh-install-requirements-cdh_blackbox
       - file: platform-testing-cdh-blackbox_service
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 platform-testing-cdh-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload

--- a/salt/platform-testing/general.sls
+++ b/salt/platform-testing/general.sls
@@ -46,7 +46,7 @@
 include:
   - python-pip
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 platform-testing-general-install_dev_deps_nmap_ncat:
   pkg.installed:
     - name: {{ pillar['nmap-ncat']['package-name'] }}
@@ -109,7 +109,7 @@ platform-testing-general-kafka_service:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-general-kafka.conf.tpl
     - name: /etc/init/platform-testing-general-kafka.conf
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/platform-testing-general-kafka.service
     - source: salt://platform-testing/templates/platform-testing-general-kafka.service.tpl
 {% endif %}
@@ -128,7 +128,7 @@ platform-testing-general-crontab-kafka:
     - user: root
 {% if grains['os'] == 'Ubuntu' %}
     - name: /sbin/start platform-testing-general-kafka
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-general-kafka
 {% endif %}
 
@@ -145,7 +145,7 @@ platform-testing-general-zookeeper-service:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-general-zookeeper.conf.tpl
     - name: /etc/init/platform-testing-general-zookeeper.conf
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/platform-testing-general-zookeeper.service
     - source: salt://platform-testing/templates/platform-testing-general-zookeeper.service.tpl
 {% endif %}
@@ -163,7 +163,7 @@ platform-testing-general-crontab-zookeeper:
     - user: root
 {% if grains['os'] == 'Ubuntu' %}
     - name: /sbin/start platform-testing-general-zookeeper
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-general-zookeeper
 {% endif %}
 
@@ -172,7 +172,7 @@ platform-testing-general-opentsdb-service:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-general-opentsdb.conf.tpl
     - name: /etc/init/platform-testing-general-opentsdb.conf
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /usr/lib/systemd/system/platform-testing-general-opentsdb.service
     - source: salt://platform-testing/templates/platform-testing-general-opentsdb.service.tpl
 {% endif %}
@@ -195,7 +195,7 @@ platform-testing-general-crontab-opentsdb:
 {% endif %}
 {% if grains['os'] == 'Ubuntu' %}
     - name: /sbin/start platform-testing-general-opentsdb
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-general-opentsdb
 {% endif %}
 
@@ -213,7 +213,7 @@ platform-testing-general-dm-blackbox_service:
 {% if grains['os'] == 'Ubuntu' %}
     - source: salt://platform-testing/templates/platform-testing-general-dm-blackbox.conf.tpl
     - name: /etc/init/platform-testing-general-dm-blackbox.conf
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - source: salt://platform-testing/templates/platform-testing-general-dm-blackbox.service.tpl
     - name: /usr/lib/systemd/system/platform-testing-general-dm-blackbox.service
 {%- endif %}
@@ -231,13 +231,13 @@ platform-testing-general-crontab-dm-blackbox:
     - user: root
 {% if grains['os'] == 'Ubuntu' %}
     - name: /sbin/start platform-testing-general-dm-blackbox
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-general-dm-blackbox
 {% endif %}
 
 {% endif %}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 platform-testing-general-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload

--- a/salt/pnda/user.sls
+++ b/salt/pnda/user.sls
@@ -3,7 +3,7 @@
 {% set pnda_group = pillar['pnda']['group'] %}
 {% set pnda_home_directory = pillar['pnda']['homedir'] %}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 permissive:
     selinux.mode
 {% endif %}

--- a/salt/pnda/user.sls
+++ b/salt/pnda/user.sls
@@ -4,6 +4,12 @@
 {% set pnda_home_directory = pillar['pnda']['homedir'] %}
 
 {% if grains['os'] in ('RedHat', 'CentOS') %}
+pnda-install_selinux:
+  pkg.installed:
+    - pkgs:
+      - policycoreutils-python
+      - selinux-policy-targeted
+
 permissive:
     selinux.mode
 {% endif %}

--- a/salt/reboot/infra.sls
+++ b/salt/reboot/infra.sls
@@ -1,4 +1,4 @@
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 reboot-install_deps:
   pkg.installed:
     - name: {{ pillar['at']['package-name'] }}

--- a/salt/reboot/install_restart.sls
+++ b/salt/reboot/install_restart.sls
@@ -37,7 +37,7 @@ reboot-copy_service:
     - template: jinja
     - defaults:
         install_dir: {{ install_dir }}
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 reboot-copy_systemd:
   file.managed:
     - name: /usr/lib/systemd/system/pnda-restart.service

--- a/salt/zookeeper/init.sls
+++ b/salt/zookeeper/init.sls
@@ -106,7 +106,7 @@ zookeeper-service:
     - mode: 644
     - require:
       - file: zookeeper-data-dir
-{% elif grains['os'] == 'RedHat' %}
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
 zookeeper-service_startpre:
     file.managed:
       - name: {{ install_dir }}/zookeeper-{{ zookeeper_version }}/bin/zookeeper-service-startpre.sh
@@ -141,7 +141,7 @@ zookeeper-systemd:
       - file: zookeeper-data-dir
 {% endif %}
 
-{% if grains['os'] == 'RedHat' %}
+{% if grains['os'] in ('RedHat', 'CentOS') %}
 zookeeper-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable zookeeper


### PR DESCRIPTION
Changes are also required in pnda mirror scripts and pnda-aws-templates for CentOS, but this can safely be merged first.