### PR TITLE
Link logstash install directory using salt file.symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - PNDA-2965: Rename `cloudera_*` role grains to `hadoop_*`
 - PNDA-3216: Uprev to logstash 5.2.2
+- PNDA-3212: Link logstash install directory using salt file.symlink command as the cmd.run version was preventing logshipper/logserver upgrades
 
 ### Fixed
 - PNDA-3213: fix issue on wrong checksum file name for logserver sls

--- a/salt/logserver/logserver.sls
+++ b/salt/logserver/logserver.sls
@@ -33,10 +33,9 @@ logserver-dl-and-extract:
     - if_missing: {{ install_dir }}/logstash-{{ logstash_version }}
 
 logserver-link_release:
-  cmd.run:
-    - name: ln -f -s {{ install_dir }}/logstash-{{ logstash_version }} {{ install_dir }}/logstash
-    - cwd: {{ install_dir }}
-    - unless: test -L {{ install_dir }}/logstash
+  file.symlink:
+    - name: {{ install_dir }}/logstash
+    - target: {{ install_dir }}/logstash-{{ logstash_version }}
 
 logserver-copy_configuration:
   file.managed:

--- a/salt/logserver/logshipper.sls
+++ b/salt/logserver/logshipper.sls
@@ -24,7 +24,7 @@ logshipper-acl:
     - name: {{ pillar['acl']['package-name'] }}
     - version: {{ pillar['acl']['version'] }}
     - ignore_epoch: True
-    
+
 logshipper-dl-and-extract:
   archive.extracted:
     - name: {{ install_dir }}
@@ -35,10 +35,9 @@ logshipper-dl-and-extract:
     - if_missing: {{ install_dir }}/logstash-{{ logstash_version }}
 
 logshipper-link_release:
-  cmd.run:
-    - name: ln -f -s {{ install_dir }}/logstash-{{ logstash_version }} {{ install_dir }}/logstash
-    - cwd: {{ install_dir }}
-    - unless: test -L {{ install_dir }}/logstash
+  file.symlink:
+    - name: {{ install_dir }}/logstash
+    - target: {{ install_dir }}/logstash-{{ logstash_version }}
 
 {% if grains['os'] == 'RedHat' %}
 logshipper-journald-plugin:


### PR DESCRIPTION
Link logstash install directory using the salt file.symlink command as
the cmd.run version was preventing logshipper/logserver upgrades

PNDA-3212