### PR TITLE
Issue 290: Deployment failed due to saltstack

### DIFF
--- a/salt/orchestrate/pnda-expand.sls
+++ b/salt/orchestrate/pnda-expand.sls
@@ -7,6 +7,7 @@ orchestrate-expand-create_cloudera_user:
     - tgt_type: compound
     - sls: cdh.cloudera_user
     - timeout: 120
+    - queue: True
 
 orchestrate-expand-install-agents:
   salt.state:
@@ -14,6 +15,7 @@ orchestrate-expand-install-agents:
     - tgt_type: compound
     - sls: cdh.cloudera-manager-agent
     - timeout: 120
+    - queue: True
 
 orchestrate-expand-install_hadoop:
   salt.state:
@@ -21,6 +23,7 @@ orchestrate-expand-install_hadoop:
     - tgt_type: compound
     - sls: cdh.setup_hadoop
     - timeout: 120
+    - queue: True
 {% endif %}
 
 {% if pillar['hadoop.distro'] == 'HDP' %}
@@ -30,6 +33,7 @@ orchestrate-expand-install_ambari_agents:
     - tgt_type: compound
     - sls: ambari.agent
     - timeout: 120
+    - queue: True
 
 orchestrate-expand-install_hdp_hadoop:
   salt.state:
@@ -37,6 +41,7 @@ orchestrate-expand-install_hdp_hadoop:
     - tgt_type: compound
     - sls: hdp.setup_hadoop
     - timeout: 120
+    - queue: True
 {% endif %}
 
 orchestrate-expand-install_platform_libraries:
@@ -45,6 +50,7 @@ orchestrate-expand-install_platform_libraries:
     - tgt_type: compound
     - sls: pnda.platform-libraries
     - timeout: 120
+    - queue: True
 
 orchestrate-expand-install_deployment_manager_keys:
   salt.state:
@@ -52,6 +58,7 @@ orchestrate-expand-install_deployment_manager_keys:
     - tgt_type: compound
     - sls: deployment-manager.keys
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-expand_remove_new_node_markers:
   salt.state:
@@ -59,8 +66,12 @@ orchestrate-pnda-expand_remove_new_node_markers:
     - tgt_type: compound
     - sls: orchestrate.remove_new_node_marker
     - timeout: 120
+    - queue: True
 
 orchestrate-expand-pnda_kernel_reboot:
-  salt.function:
+  salt.state:
     - tgt: '*'
-    - name: kernel_reboot.reboot
+    - tgt_type: compound
+    - sls: reboot.kernel_reboot
+    - timeout: 120
+    - queue: True

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -7,6 +7,7 @@ orchestrate-pnda-run_cloudera_user:
     - tgt_type: compound
     - sls: cdh.cloudera_user
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_hadoop_manager:
   salt.state:
@@ -14,6 +15,7 @@ orchestrate-pnda-install_hadoop_manager:
     - tgt_type: compound
     - sls: cdh.cloudera-manager
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install-agents:
   salt.state:
@@ -21,6 +23,7 @@ orchestrate-pnda-install-agents:
     - tgt_type: compound
     - sls: cdh.cloudera-manager-agent
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_cdh_hadoop:
   salt.state:
@@ -28,6 +31,7 @@ orchestrate-pnda-install_cdh_hadoop:
     - tgt_type: compound
     - sls: cdh.setup_hadoop
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-impala_wrapper:
   salt.state:
@@ -35,6 +39,7 @@ orchestrate-pnda-impala_wrapper:
     - tgt_type: compound
     - sls: cdh.impala-shell
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-hue_setup:
   salt.state:
@@ -42,6 +47,7 @@ orchestrate-pnda-hue_setup:
     - tgt_type: compound
     - sls: cdh.hue-login
     - timeout: 120
+    - queue: True
 {% endif %}
 
 {% if pillar['hadoop.distro'] == 'HDP' %}
@@ -51,6 +57,7 @@ orchestrate-pnda-install_ambari_server:
     - tgt_type: compound
     - sls: ambari.server
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_ambari_agents:
   salt.state:
@@ -58,6 +65,7 @@ orchestrate-pnda-install_ambari_agents:
     - tgt_type: compound
     - sls: ambari.agent
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_hdp_hadoop:
   salt.state:
@@ -65,6 +73,7 @@ orchestrate-pnda-install_hdp_hadoop:
     - tgt_type: compound
     - sls: hdp.setup_hadoop
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_hdp_hadoop_additional_roles:
   salt.state:
@@ -72,6 +81,7 @@ orchestrate-pnda-install_hdp_hadoop_additional_roles:
     - tgt_type: compound
     - sls: hdp.start_additional_roles
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_hdp_hadoop_httpfs:
   salt.state:
@@ -79,6 +89,7 @@ orchestrate-pnda-install_hdp_hadoop_httpfs:
     - tgt_type: compound
     - sls: hdp.httpfs
     - timeout: 120
+    - queue: True
 {% endif %}
 
 orchestrate-pnda-create_master_dataset:
@@ -87,6 +98,7 @@ orchestrate-pnda-create_master_dataset:
     - tgt_type: compound
     - sls: master-dataset
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_gobblin:
   salt.state:
@@ -94,6 +106,7 @@ orchestrate-pnda-install_gobblin:
     - tgt_type: compound
     - sls: gobblin
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_platform_libraries:
   salt.state:
@@ -101,6 +114,7 @@ orchestrate-pnda-install_platform_libraries:
     - tgt_type: compound
     - sls: pnda.platform-libraries
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_jupyter:
   salt.state:
@@ -108,6 +122,7 @@ orchestrate-pnda-install_jupyter:
     - tgt_type: compound
     - sls: jupyter
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-configure_yarn_for_spark:
   salt.state:
@@ -115,6 +130,7 @@ orchestrate-pnda-configure_yarn_for_spark:
     - tgt_type: compound
     - sls: cdh.create-yarn-home
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_deployment_manager:
   salt.state:
@@ -122,6 +138,7 @@ orchestrate-pnda-install_deployment_manager:
     - tgt_type: compound
     - sls: deployment-manager
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_deployment_manager_keys:
   salt.state:
@@ -129,6 +146,7 @@ orchestrate-pnda-install_deployment_manager_keys:
     - tgt_type: compound
     - sls: deployment-manager.keys
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-create_hbase_opentsdb_tables:
   salt.state:
@@ -136,6 +154,7 @@ orchestrate-pnda-create_hbase_opentsdb_tables:
     - tgt_type: compound
     - sls: opentsdb.hbase_tables
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-km_create_cluster:
   salt.state:
@@ -143,6 +162,7 @@ orchestrate-pnda-km_create_cluster:
     - tgt_type: compound
     - sls: kafka-manager.pnda_create_cluster
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_data_service:
   salt.state:
@@ -150,6 +170,7 @@ orchestrate-pnda-install_data_service:
     - tgt_type: compound
     - sls: data-service
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_opentsdb:
   salt.state:
@@ -157,6 +178,7 @@ orchestrate-pnda-install_opentsdb:
     - tgt_type: compound
     - sls: pnda_opentsdb.conf
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_hdfs_cleaner:
   salt.state:
@@ -164,6 +186,7 @@ orchestrate-pnda-install_hdfs_cleaner:
     - tgt_type: compound
     - sls: hdfs-cleaner
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-kafka_create_topics:
   salt.state:
@@ -171,6 +194,7 @@ orchestrate-pnda-kafka_create_topics:
     - tgt_type: compound
     - sls: platform-testing.create_topic
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-data_service-create_datasets:
   salt.state:
@@ -178,6 +202,7 @@ orchestrate-pnda-data_service-create_datasets:
     - tgt_type: compound
     - sls: data-service.create_datasets
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda-install_test_modules:
   salt.state:
@@ -185,6 +210,7 @@ orchestrate-pnda-install_test_modules:
     - tgt_type: compound
     - sls: platform-testing.cdh
     - timeout: 120
+    - queue: True
 
 {% if pillar['hadoop.distro'] == 'HDP' %}
 orchestrate-pnda-install_hdp_hadoop_oozie_libs:
@@ -193,6 +219,7 @@ orchestrate-pnda-install_hdp_hadoop_oozie_libs:
     - tgt_type: compound
     - sls: hdp.oozie_libs
     - timeout: 120
+    - queue: True
 {% endif %}
 
 orchestrate-pnda-install_remove_new_node_markers:
@@ -201,8 +228,12 @@ orchestrate-pnda-install_remove_new_node_markers:
     - tgt_type: compound
     - sls: orchestrate.remove_new_node_marker
     - timeout: 120
+    - queue: True
 
 orchestrate-pnda_kernel_reboot:
-  salt.function:
+  salt.state:
     - tgt: '*'
-    - name: kernel_reboot.reboot
+    - tgt_type: compound
+    - sls: reboot.kernel_reboot
+    - timeout: 120
+    - queue: True

--- a/salt/reboot/kernel_reboot.sls
+++ b/salt/reboot/kernel_reboot.sls
@@ -1,0 +1,3 @@
+reboot-Kernel_reboot:
+  module.run:
+    - name: kernel_reboot.reboot


### PR DESCRIPTION
Problem Statement:
    By default SaltStack not queuing job, need to enable  queue in all salt calls

Analysis:
    Enable the beacon at any point of time one job would have been running i.e HIGH State or each of the Orchestrate states. After the beacon configuring, beacon run in the specified intervals (for milli seconds or so) . As per default salt state flow, only one job can run at any point of time.  Now if another job starts at the same time, the salt will not allow it. Now if we want salt jobs in parallel we need to specify a parameter called queue = True. By default it is False. 

Change:
The fix is needed to be in aws-template  <pnda-cli.py> and heat template for HIGH state and in pnda-salt orchestrate all the jobs to be added with this parameter. 

Test details:
    Run deployment several times and ensure it will not break in the middle.
