### PR TITLE
Issue293:OpenTsdb service not running after deployment

### DIFF
--- a/salt/_beacons/service_opentsdb.py
+++ b/salt/_beacons/service_opentsdb.py
@@ -1,0 +1,38 @@
+# Import python libs
+"""
+  To monitor pnda opentsdb service status
+"""
+from __future__ import absolute_import
+
+import requests
+import logging
+import json
+import re
+
+logger = logging.getLogger(__name__)
+
+
+def beacon(config):# pylint: disable=W0612,W0613
+    """
+      Beacons let you use the Salt event system to monitor non-Salt processes
+    """
+    ret_dict = dict()
+    ret = list()
+    if  __salt__['service.status']('opentsdb'):# pylint: disable=E0602,E0603
+        ret_dict['tag'] = 'service/opentsdb/status/running'
+        return [ret_dict]
+    hadoop_distro = __salt__['pillar.get']('hadoop.distro')  # pylint: disable=E0602,E0603
+    if hadoop_distro == 'CDH':
+        hBaseStatus =  __salt__['pnda.cloudera_get_service_status']('hbase01')# pylint: disable=E0602,E0603
+        if re.search("GOOD|CONCERNING",hBaseStatus):
+            ret_dict['tag'] = 'service/opentsdb/status/stop/HBaseUp'
+            return [ret_dict]
+    else:
+        hBaseStatus =  __salt__['pnda.ambari_get_service_status']('HBASE')# pylint: disable=E0602,E0603
+        if re.search("STARTED",hBaseStatus):
+            ret_dict['tag'] = 'service/opentsdb/status/stop/HBaseUp'
+            return [ret_dict]
+
+    ret_dict['tag'] = 'service/opentsdb/status/stop/HBaseDown'
+    return [ret_dict]
+

--- a/salt/_modules/pnda.py
+++ b/salt/_modules/pnda.py
@@ -143,3 +143,30 @@ def get_hosts_by_role(service, role_type):
         return cloudera_get_hosts_by_role(service, role_type)
     else:
         return ambari_get_hosts_by_role(service, role_type)
+
+def cloudera_get_service_status(service):
+    user = hadoop_manager_username()
+    password = hadoop_manager_password()
+    endpoint = hadoop_manager_ip() + ':7180'
+    cluster = cluster_name()
+
+    request_url = 'http://{}/api/v14/clusters/{}/services/{}'.format(endpoint, cluster, service)
+    response = requests.get(request_url, auth=(user, password))
+    response.raise_for_status()
+    service_resp = response.json()
+
+    return service_resp['healthSummary']
+
+
+def ambari_get_service_status(service):
+    user = hadoop_manager_username()
+    password = hadoop_manager_password()
+    endpoint = hadoop_manager_ip() + ':8080'
+    cluster = cluster_name()
+
+    request_url = 'http://{}/api/v1/clusters/{}/services/{}'.format(endpoint, cluster, service)
+    response = requests.get(request_url, auth=(user, password))
+    response.raise_for_status()
+    service_resp = response.json()
+
+    return service_resp['ServiceInfo']['state']

--- a/salt/opentsdb/service.sls
+++ b/salt/opentsdb/service.sls
@@ -1,0 +1,3 @@
+opentsdb-service_start:
+  service.running:
+    - name: opentsdb

--- a/salt/reactor/service_opentsdb_entry.sls
+++ b/salt/reactor/service_opentsdb_entry.sls
@@ -1,0 +1,5 @@
+reactor-openTsdb_service_start:
+  local.state.sls:
+    - arg:
+      - opentsdb.service
+    - tgt: {{ data['data']['id'] }}


### PR DESCRIPTION
Problem Statement:
OpenTsdb service is not running after deployment

Analysis:
1. OpenTsdb service needs HBase service
2. if openTsdb started before HBase , it will down
3. PNDA-2389 restart the nodes after deployment, this cause the order of service placement
4. Need to start the OpenTsdb again after HBase is up

Change:

1. implement the Beacon and reactor method to implement fix
2. implement beacon only in OpenTsdb node only 
3. Check the Opentsdb status and Hbase status <ambari or cludera>
4. if OpenTsdb is Down and Habse is up, send the following tag to reactor 
+  - 'salt/beacon/*/service_opentsdb/service/opentsdb/status/stop/HBaseUp':
5. reactor will start the service again


Test details:
1. Need to test  all 16<2^4> combinations (OS,AWS),(HDP,CDH),(pico,standard),(redhat,ubuntu)
2. tested in AWS , testing pending in  Openstack.
3. Now opentsdb running after deployment.
4. stopped opentsdb nodes , and it's comes up automatically
