### PR TITLE
PNDA 2390: PNDA restarts any services that need restarting when rebooted

### DIFF
--- a/salt/_beacons/service_restart.py
+++ b/salt/_beacons/service_restart.py
@@ -1,26 +1,54 @@
-# Import python libs
 """
   To monitor pnda service status
 """
 from __future__ import absolute_import
 
 import logging
+# retry the start service only for every DOWN_COUNT_MAX
+DOWN_COUNT_MAX = 10
+# maximum retry count is RETRY_COUNT_MAX
+RETRY_COUNT_MAX = 3
+# retry_count will reset after RETRY_COUNT_MAX
+RETRY_COUNT_RESET = 10
 
 LOGGER = logging.getLogger(__name__)
-
 
 def beacon(config):# pylint: disable=W0612,W0613
     """
       Beacons let you use the Salt event system to monitor non-Salt processes
     """
+    hadoop_distro = __salt__['pnda.hadoop_distro']()# pylint: disable=E0602,E0603
+    cluster_name = __salt__['pnda.cluster_name']()# pylint: disable=E0602,E0603
     ret_dict = dict()
     ret = list()
-    result = __salt__['pnda_service_restart.managehadoopclusterrestart']()# pylint: disable=E0602,E0603
+    if hadoop_distro == 'CDH' :
+      result = __salt__['pnda_service_restart.managehadoopclusterrestart']()# pylint: disable=E0602,E0603
+      if result:
+        ret_dict['tag'] = 'service/hadoop/status/restarted'
+      else:
+        ret_dict['tag'] = 'service/hadoop/status/failed'
+        ret.append(ret_dict)
+      return ret
 
-    if result:
-        ret_dict['Restarted'] = True
-        ret.append(ret_dict)
-    else:
-        ret_dict['Restarted'] = False
-        ret.append(ret_dict)
-    return ret
+    #HDP Config
+    servicelist = __salt__['grains.get']('serviceList')  # pylint: disable=E0602,E0603
+    if not servicelist:
+       servicelist = {'up_count': 0,'down_count': 0,'retry_count': 0}
+	
+    health_report =__salt__['pnda.ambari_get_cluster_health_report']()# pylint: disable=E0602,E0603
+    if (health_report['Host/host_status/HEALTHY']  !=
+        health_report['Host/host_state/HEALTHY']):
+        ret_dict['tag'] = 'service/hadoop/status/stopped'
+        servicelist['down_count'] += 1
+    else :
+        ret_dict['tag'] = 'service/hadoop/status/running'
+        servicelist['up_count'] += 1
+        if servicelist['up_count'] > RETRY_COUNT_RESET:
+           servicelist['retry_count'] = 0
+
+    __salt__['grains.set']("serviceList", {}, True)  # pylint: disable=E0602,E0603
+    __salt__['grains.set'](  # pylint: disable=E0602,E0603
+        "serviceList", servicelist, True)
+
+    return [ret_dict]
+

--- a/salt/_modules/pnda.py
+++ b/salt/_modules/pnda.py
@@ -170,3 +170,7 @@ def ambari_get_service_status(service):
     service_resp = response.json()
 
     return service_resp['ServiceInfo']['state']
+def ambari_get_cluster_health_report():
+    health_report = ambari_request('/clusters/'+cluster_name())
+    return health_report['Clusters']['health_report']
+

--- a/salt/_states/ambari_hadoop_restart.py
+++ b/salt/_states/ambari_hadoop_restart.py
@@ -1,0 +1,123 @@
+"""
+Post system reboot status to the console backend
+"""
+import json
+import time
+import requests
+import logging
+
+# retry the start service only for every DOWN_COUNT_MAX
+DOWN_COUNT_MAX = 3
+# maximum retry count is RETRY_COUNT_MAX
+RETRY_COUNT_MAX = 3
+# retry_count will reset after RETRY_COUNT_MAX
+RETRY_COUNT_RESET = 10
+
+def ambari_request( uri, body=None):
+    hadoop_manager_ip = __salt__['pnda.hadoop_manager_ip']()
+    hadoop_manager_username = __salt__['pillar.get']('admin_login:user')
+    hadoop_manager_password = __salt__['pillar.get']('admin_login:password')
+
+    if uri.startswith("http"):
+        full_uri = uri
+    else:
+        full_uri = 'http://%s:8080/api/v1%s' % (hadoop_manager_ip, uri)
+
+    headers = {'X-Requested-By': hadoop_manager_username}
+    auth = (hadoop_manager_username, hadoop_manager_password)
+    if body is None:
+        response = requests.get(full_uri, auth=auth, headers=headers)
+    else:
+        response = requests.put(full_uri, body, auth=auth, headers=headers)
+    logging.error(response.text)
+    try:
+        return response.json()
+    except ValueError:
+        return None
+
+def wait_on_cmd( tracking_uri, msg):
+    logging.info('Waiting for %s %s...', tracking_uri,msg)
+    progress_percent = 0
+    while progress_percent < 100:
+        time.sleep(5)
+        status_reponse = ambari_request(tracking_uri)
+        logging.debug(status_reponse['Requests'])
+        cmd_status = status_reponse['Requests']['request_status']
+        progress_percent = int(status_reponse['Requests']['progress_percent'])
+        logging.info('Progress for %s: %s%% - %s', tracking_uri, progress_percent, cmd_status)
+    return cmd_status
+def get_request_status(tracking_uri):
+    status_reponse = ambari_request(tracking_uri)
+    ret = {
+        'changes': {},
+        'result': True
+    }
+
+    resp = status_reponse['Requests']
+    if resp['timed_out_task_count'] or resp['aborted_task_count'] \
+        or resp['failed_task_count'] or resp['queued_task_count'] \
+        or resp['timed_out_task_count']:
+	   ret['result'] = False
+    ret['changes']['Requests'] = status_reponse['Requests']
+    host_name = []
+    role = []
+    status = []
+    stderr = []
+    for task in status_reponse['tasks']:
+        task_reponse = ambari_request(task['href'])
+        host_name.append(task_reponse['Tasks']['host_name'])
+        role.append(task_reponse['Tasks']['role'])
+        status.append(task_reponse['Tasks']['status'])
+        stderr.append(task_reponse['Tasks']['stderr'])
+    ret['changes']['tasks'] = {'host_name': host_name,
+                               'role': role,
+	                       'status': status,
+                               'stderr': stderr}
+    return ret
+
+
+def start_all_services(name):
+    """  post kernel reboot status to metric page"""
+    ret = {
+        'name': name,
+        'changes': {},
+        'result': False,
+        'comment': '',
+        'pchanges': {},
+    }
+    servicelist = __salt__['grains.get']('serviceList')  # pylint: disable=E0602,E0603
+    if not servicelist:
+       servicelist = {'up_count': 0,'down_count': 0,'retry_count': 0}
+    if servicelist['retry_count'] > RETRY_COUNT_MAX:
+        ret['result'] = True
+        ret['comment'] = "Max retry count {} reached, not starting services".format(RETRY_COUNT_MAX)
+        return ret
+    if servicelist['down_count'] < DOWN_COUNT_MAX:
+        ret['result'] = True
+        ret['comment'] = "Max down count {} not reached, so not starting services".format(DOWN_COUNT_MAX)
+        return ret
+
+        
+
+    cluster_name = __salt__['pnda.cluster_name']()# pylint: disable=E0602,E0603
+    start_command = '''{
+        "RequestInfo": {
+            "context": "_PARSE_.START.ALL_SERVICES",
+            "operation_level": {
+                "level": "CLUSTER",
+                "cluster_name": "%s"
+            }
+        },
+        "Body": {
+            "ServiceInfo": {
+                "state": "STARTED"
+            }
+        }
+    }''' % cluster_name
+    response = ambari_request( '/clusters/%s/services' % (cluster_name), start_command)
+    if response is not None:
+        wait_on_cmd( response['href'], 'services to be started by Ambari')
+        status = get_request_status( response['href'])
+        ret['result'] = status['result']
+        ret['changes'] = status['changes']
+    return ret

--- a/salt/hdp/service.sls
+++ b/salt/hdp/service.sls
@@ -1,0 +1,2 @@
+Restart HDP services:
+  ambari_hadoop_restart.start_all_services

--- a/salt/reactor/service_hadoop_start_entry.sls
+++ b/salt/reactor/service_hadoop_start_entry.sls
@@ -1,0 +1,5 @@
+reactor-hadoop_service_start:
+  local.state.sls:
+    - arg:
+      - hdp.service
+    - tgt: {{ data['data']['id'] }}


### PR DESCRIPTION
**# Problem Statement:**
PNDA 2390: NDA restarts any services that need restarting when rebooted

**# Analysis:**
   Hadoop services are down due to node reboot or other issues
   Services once down needs user intervention to start services
   Need to automate the start process
**# Change:**
   Fix supports for Ambari (HDP distribution)
   implement the Beacon and reactor method to implement the fix
   
   **BEACON:**
   Beacon verify the current status using REST API <http://10.0.1.246:8080/api/v1/clusters/jana/>
   Verify the health report and if any node down, starts the service
   
   **REACTOR:**
   verify the retry count, if it's less than 3 starts the process
   print name of the services changed the state with a hostname
   
   
**# Test details:**
   
   Verified  the fix for AWS:
   1. UBUNTU - PICO -HDP
   2. UBUNTU - STD -HDP
   3. RHEL - PICO -HDP
   3. RHEL - STD -HDP 
   
  **Verification pending for OpenStack**
  **CDH testing not required, Fix applicable for HDP.**
  
  