### PR TITLE
Add developer and production users as default users of the platform.

### DIFF
--- a/pillar/identity.sls
+++ b/pillar/identity.sls
@@ -1,0 +1,11 @@
+identity:
+  pam_module: 'pam_unix'
+  users:
+    - dev:
+      user: 'dev1'
+      group: 'dev'
+      password_hash: $6$g4LehAEw$fhyAl9nA4rThE8xulAFDQHFLDM2Qg9YK0ommXLyrGuaie.r3PqyhYj2STTUmv2JMiGZqAqHfhtrb3Ex4rmU6w.
+    - prod:
+      user: 'prod1'
+      group: 'prod'
+      password_hash: $6$g4LehAEw$.atObqyvbQPp/ABbZxDzqWRvE.UqL1cw4jBH3f0zv4OvlruKKUMO5FbT6YBQQAanhbuk5rIxzPnVxKR74Y3HV1 

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -1,6 +1,7 @@
 {{ saltenv }}:
   '*':
     - pnda
+    - identity
     - flavors.{{ salt['grains.get']('pnda:flavor', 'standard') }}
     - services
     - env_parameters

--- a/salt/identity/users.sls
+++ b/salt/identity/users.sls
@@ -1,0 +1,24 @@
+{% if pillar['identity']['pam_module'] == 'pam_unix' %}
+
+{% for usr in pillar['identity']['users'] %}
+
+{% set user = usr['user'] %}
+{% set password = usr['password_hash'] %}
+{% set group = usr['group'] %}
+{% set pnda_group = pillar['pnda']['group'] %}
+
+pnda-create_{{ group }}_group:
+  group.present:
+    - name: {{ group }}
+
+pnda-create_{{ user }}_user:
+  user.present:
+    - name: {{ user }}
+    - password: {{ password }}
+    - createhome: True
+    - gid: {{ group }}
+    - groups:
+      - {{ pnda_group }}
+
+{% endfor %}
+{% endif %}

--- a/salt/master-dataset/pnda_hdfs_user.sls
+++ b/salt/master-dataset/pnda_hdfs_user.sls
@@ -6,3 +6,19 @@ master-dataset-create_hdfs_pnda_home:
     - name: hdfs dfs -mkdir /user/{{ pnda_user }} && hdfs dfs -chown {{ pnda_user }}:{{ pnda_group }} /user/{{ pnda_user }} && hdfs dfs -chmod 770 /user/{{ pnda_user }}
     - user: hdfs
     - unless: hdfs dfs -test -d /user/{{ pnda_user }}
+
+{% if pillar['identity']['pam_module'] == 'pam_unix' %}
+
+{% for usr in pillar['identity']['users'] %}
+
+{% set user = usr['user'] %}
+{% set group = usr['group'] %}
+
+master-dataset-create_hdfs_{{ user }}_home:
+  cmd.run:
+    - name: hdfs dfs -mkdir /user/{{ user }} && hdfs dfs -chown {{ user }}:{{ group }} /user/{{ user }} && hdfs dfs -chmod 770 /user/{{ user }}
+    - user: hdfs
+    - unless: hdfs dfs -test -d /user/{{ user }}
+
+{% endfor %}
+{% endif %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -4,6 +4,7 @@
     - tasks.system_update
     - motd
     - pnda.user
+    - identity.users
     - hostsfile
     - java
     - java.env


### PR DESCRIPTION
These will only be injected if the authentication is based on the
pam_unix mode.