### PR TITLE
Support for adding pyspark application dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Added
 - PNDA-2389: PNDA automatically reboots instances that need rebooting following kernel updates
+- PNDA-2982: Added support for adding pyspark application dependencies
 
 ### Added
 - PNDA-1960: Make Kafkat available on nodes as option for Kafka management at CLI

--- a/pillar/pnda.sls
+++ b/pillar/pnda.sls
@@ -9,3 +9,6 @@ pnda:
     directory: /user/pnda/PNDA_datasets/datasets
     quarantine_directory: /user/pnda/PNDA_datasets/quarantine
     bulk_directory: /user/pnda/PNDA_datasets/bulk
+  
+  app_packages:
+    app_packages_hdfs_path: /user/deployment/app_packages

--- a/salt/app-packages/files/app-packages-hdfs.txt
+++ b/salt/app-packages/files/app-packages-hdfs.txt
@@ -1,0 +1,2 @@
+# App dependency packages to be staged on HDFS for use in pyspark executors
+

--- a/salt/app-packages/files/app-packages-requirements.txt
+++ b/salt/app-packages/files/app-packages-requirements.txt
@@ -1,0 +1,1 @@
+# App dependency packages to be installed for use in pyspark and Jupyter clients

--- a/salt/app-packages/hdfs-sync.sls
+++ b/salt/app-packages/hdfs-sync.sls
@@ -1,0 +1,28 @@
+{% set pnda_home = pillar['pnda']['homedir'] %}
+{% set pnda_mirror = pillar['pnda_mirror']['base_url'] %}
+{% set app_packages_hdfs_path = pillar['pnda']['app_packages']['app_packages_hdfs_path'] %}
+{% set app_packages_mirror_path = pillar['pnda_mirror']['app_packages_path'] %}
+{% set app_packages_fs_path = pnda_home + "/apps-packages" %}
+{% set mirror_url = pnda_mirror + app_packages_mirror_path %}
+
+app-packages-create-directory:
+  file.directory:
+    - name: {{ app_packages_fs_path }}
+    - mode: 755
+    - makedirs: True
+
+app-packages-instantiate-package-list:
+  file.managed:
+    - name: {{ app_packages_fs_path }}/app-packages-hdfs.txt
+    - source: salt://app-packages/files/app-packages-hdfs.txt
+    - template: jinja
+
+app-packages-sync-hdfs:
+  cmd.script:
+    - name: salt://app-packages/templates/sync.sh.tpl
+    - template: jinja
+    - context:
+        app_packages_hdfs_path : {{ app_packages_hdfs_path }}
+        mirror_url: {{ mirror_url }}
+        app_packages_fs_path: {{ app_packages_fs_path }}/app-packages-hdfs.txt
+    - cwd: {{ app_packages_fs_path }}

--- a/salt/app-packages/init.sls
+++ b/salt/app-packages/init.sls
@@ -1,0 +1,19 @@
+{% set pnda_home = pillar['pnda']['homedir'] %}
+{% set pip_index_url = pillar['pip']['index_url'] %}
+{% set app_packages_hdfs_path = pillar['pnda']['app_packages']['app_packages_hdfs_path'] %}
+
+include:
+  - python-pip
+
+app-packages-create-venv:
+  virtualenv.managed:
+    - name: {{ pnda_home }}/app-packages
+    - python: python2
+    - requirements: salt://app-packages/files/app-packages-requirements.txt
+    - index_url: {{ pip_index_url }}
+    - require:
+      - pip: python-pip-install_python_pip
+
+app-packages-initialize-hdfs:
+  cmd.run:
+    - name: 'sudo -u hdfs hdfs dfs -mkdir -p {{ app_packages_hdfs_path }}'

--- a/salt/app-packages/templates/sync.sh.tpl
+++ b/salt/app-packages/templates/sync.sh.tpl
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+declare -A HDFS
+EXISTING=$(sudo -u hdfs hdfs dfs -stat "%n" {{ app_packages_hdfs_path }}/* || : 2>/dev/null)
+for e in ${EXISTING[@]}
+do
+  HDFS[$e]=
+done
+CANDIDATES=$(grep -v '^#' {{ app_packages_fs_path }})
+TARGETS=()
+for c in ${CANDIDATES[@]}
+do
+  if ! [[ ${HDFS[$c]+unassigned} ]]; then
+    TARGETS+=($c)
+    echo "Uploading new package ${c}"
+    curl -fsO {{ mirror_url }}/$c
+    [[ $? -ne 0 ]] && echo "Error downloading ${c} from mirror" && exit -1
+    sudo -u hdfs hdfs dfs -put $c {{ app_packages_hdfs_path }}/
+    [[ $? -ne 0 ]] && echo "Error uploading ${c} to HDFS" && exit -1
+  fi
+done
+{% raw %}
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  echo "Nothing to upload"
+fi
+{% endraw %}

--- a/salt/cdh/setup_hadoop.sls
+++ b/salt/cdh/setup_hadoop.sls
@@ -13,6 +13,8 @@
 {% set aws_key = salt['pillar.get']('aws.archive_key', '') %}
 {% set aws_secret_key = salt['pillar.get']('aws.archive_secret', '') %}
 {% set pip_index_url = pillar['pip']['index_url'] %}
+{% set pnda_home = pillar['pnda']['homedir'] %}
+{% set app_packages_dir = pnda_home + "/apps-packages" %}
 
 include:
   - python-pip
@@ -58,6 +60,7 @@ cdh-copy_cm_config:
       mysql_host: {{ mysql_host }}
       aws_key: {{ aws_key }}
       aws_secret_key: {{ aws_secret_key }}
+      app_packages_dir: {{ app_packages_dir }}
 
 # Create a python configured scripts to call the cm_setup.setup_hadoop function with
 # the needed aguments (nodes to install cloudera to)

--- a/salt/cdh/templates/cfg_bmstandard.py.tpl
+++ b/salt/cdh/templates/cfg_bmstandard.py.tpl
@@ -435,7 +435,8 @@ SPARK_CFG = {
     'service': 'SPARK_ON_YARN',
     'name': 'spark_on_yarn',
     'config': {
-        'yarn_service': MAPRED_CFG['name']
+        'yarn_service': MAPRED_CFG['name'],
+        'spark-conf/spark-env.sh_service_safety_valve': "SPARK_PYTHON_PATH={{ app_packages_dir }}/lib/python2.7/site-packages\nexport PYTHONPATH=\"$PYTHONPATH:$SPARK_PYTHON_PATH\""
     },
     'roles': [
         {'name': 'spark', 'type': 'SPARK_YARN_HISTORY_SERVER', 'target': 'MGR02'},

--- a/salt/cdh/templates/cfg_pico.py.tpl
+++ b/salt/cdh/templates/cfg_pico.py.tpl
@@ -535,7 +535,8 @@ SPARK_CFG = {
     'service': 'SPARK_ON_YARN',
     'name': 'spark_on_yarn',
     'config': {
-        'yarn_service': MAPRED_CFG['name']
+        'yarn_service': MAPRED_CFG['name'],
+        'spark-conf/spark-env.sh_service_safety_valve': "SPARK_PYTHON_PATH={{ app_packages_dir }}/lib/python2.7/site-packages\nexport PYTHONPATH=\"$PYTHONPATH:$SPARK_PYTHON_PATH\""
     },
     'roles': [
         {'name': 'spark', 'type': 'SPARK_YARN_HISTORY_SERVER', 'target': 'MGR01'},

--- a/salt/cdh/templates/cfg_standard.py.tpl
+++ b/salt/cdh/templates/cfg_standard.py.tpl
@@ -444,7 +444,8 @@ SPARK_CFG = {
     'service': 'SPARK_ON_YARN',
     'name': 'spark_on_yarn',
     'config': {
-        'yarn_service': MAPRED_CFG['name']
+        'yarn_service': MAPRED_CFG['name'],
+        'spark-conf/spark-env.sh_service_safety_valve':"SPARK_PYTHON_PATH={{ app_packages_dir }}/lib/python2.7/site-packages\nexport PYTHONPATH=\"$PYTHONPATH:$SPARK_PYTHON_PATH\""
     },
     'roles': [
         {'name': 'spark', 'type': 'SPARK_YARN_HISTORY_SERVER', 'target': 'MGR03'},

--- a/salt/jupyter/jupyter.sls
+++ b/salt/jupyter/jupyter.sls
@@ -1,8 +1,8 @@
 {% set pnda_home_directory = pillar['pnda']['homedir'] %}
 {% set virtual_env_dir = pnda_home_directory + '/jupyter' %}
 {% set pip_index_url = pillar['pip']['index_url'] %}
-
 {% set jupyter_kernels_dir = '/usr/local/share/jupyter/kernels' %}
+{% set app_packages_home = pnda_home_directory + '/app-packages' %}
 
 {% if pillar['hadoop.distro'] == 'HDP' %}
 {% set anaconda_home = '/opt/pnda/anaconda' %}
@@ -63,6 +63,7 @@ jupyter-copy_pyspark_kernel:
         anaconda_home: {{ anaconda_home }}
         spark_home: {{ spark_home }}
         hadoop_conf_dir: {{ hadoop_conf_dir }}
+        app_packages_home: {{ app_packages_home }}
 
 #copy data-generator.py script
 jupyter-copy_data_generator_script:

--- a/salt/jupyter/templates/pyspark_kernel.json.tpl
+++ b/salt/jupyter/templates/pyspark_kernel.json.tpl
@@ -12,7 +12,7 @@
   "HADOOP_CONF_DIR":"{{ hadoop_conf_dir }}",
   "PYSPARK_PYTHON":"{{ anaconda_home }}/bin/python",
   "SPARK_HOME": "{{ spark_home }}",
-  "PYTHONPATH": "{{ spark_home }}/python:{{ spark_home }}/python/lib/py4j-0.9-src.zip",
+  "PYTHONPATH": "{{ app_packages_home }}/lib/python2.7/site-packages:{{ spark_home }}/python:{{ spark_home }}/python/lib/py4j-0.9-src.zip",
   "PYTHONSTARTUP": "{{ spark_home }}/python/pyspark/shell.py",
   "PYSPARK_SUBMIT_ARGS": "--master yarn-client --jars {{ spark_home }}/lib/spark-examples.jar pyspark-shell"
  }

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -222,6 +222,14 @@ orchestrate-pnda-install_hdp_hadoop_oozie_libs:
     - queue: True
 {% endif %}
 
+orchestrate-pnda-app-packages:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and ( G@hadoop:role:EDGE or G@roles:jupyter )'
+    - tgt_type: compound
+    - sls: app-packages
+    - timeout: 120
+    - queue: True
+
 orchestrate-pnda-install_remove_new_node_markers:
   salt.state:
     - tgt: 'G@pnda_cluster:{{pnda_cluster}}'


### PR DESCRIPTION
Support for adding pyspark application dependencies to both
pyspark-shell and Jupyter and for both driver and executor
scoped resolution. 

New ops SLS hdfs-sync stages eggs to a configurable (pillar) location
in HDFS, from where they can be added for executors with addPyFile.
Meanwhile, main SLS sets up virtualenvs to act as repositories on the
edge and Jupyter nodes for driver dependencies (in YARN client mode). 

Dependencies lists are managed through two files, much like any other set
of dependencies in platform-salt.

This PR omits support for pyspark-shell in HDP (Jupyter is covered).

PNDA-2982