### PR TITLE
When expanding cluster include spark on yarn service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3216: Use new logstash plugin mechanism in 5.2.2 that actually works when offline
 - PNDA-3111: Report failures up if opentsdb.hbase_tables fails
 - PNDA-3309: use local gem installation for Kafka tool
+- PNDA-3343: When expanding a cluster new datanodes are given a spark gateway role
 
 ## [2.0.0] 2017-05-23
 ### Added

--- a/salt/cdh/files/cm_setup.py
+++ b/salt/cdh/files/cm_setup.py
@@ -390,6 +390,9 @@ def expand_services(cluster, nodes):
         logging.info("Expanding Impala")
         impala = generic_expand_service(cluster, _CFG.IMPALA_CFG, nodes)
 
+        logging.info("Expanding Spark On Yarn")
+        spark = generic_expand_service(cluster, _CFG.SPARK_CFG, nodes)
+
         time.sleep(10)
         logging.info("Deploying client config")
         wait_on_success(cluster.deploy_client_config())


### PR DESCRIPTION
When expanding a cluster include spark on yarn so that new datanodes
are given a spark gateway role.

PNDA-3343