### PR TITLE
Write CM_SETUP_SUCCESS into a fixed directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3216: Use new logstash plugin mechanism in 5.2.2 that actually works when offline
 - PNDA-3111: Report failures up if opentsdb.hbase_tables fails
 - PNDA-3309: use local gem installation for Kafka tool
+- PNDA-3309: Write `CM_SETUP_SUCCESS` into a fixed directory
 
 ## [2.0.0] 2017-05-23
 ### Added

--- a/salt/cdh/files/cm_setup.py
+++ b/salt/cdh/files/cm_setup.py
@@ -26,7 +26,7 @@ DEFAULT_PARCEL_REPO = 'http://archive.cloudera.com/cdh5/parcels/5.9.0/'
 DEFAULT_PARCEL_VERSION = '5.9.0-1.cdh5.9.0.p0.23'
 
 DEFAULT_LOG_FILE = '/var/log/pnda/hadoop_setup.log'
-SETUP_SUCCESS = os.path.expanduser('~/.CM_SETUP_SUCCESS')
+SETUP_SUCCESS = os.path.expanduser('/opt/pnda/.CM_SETUP_SUCCESS')
 
 logging.basicConfig(filename=DEFAULT_LOG_FILE,
                     level=logging.INFO,


### PR DESCRIPTION
CM_SETUP_SUCCESS was being written to ~/ which would change depending
on which user ran cm_setup. This is fixed to /opt/pnda so different
users can run cm_setup from run to run.

PNDA-3340