### PR TITLE
Disable rebooting for HDP clusters until that works reliably

### DIFF
--- a/salt/_modules/kernel_reboot.py
+++ b/salt/_modules/kernel_reboot.py
@@ -21,6 +21,11 @@ def required():
     """ returns system needs reboot required or not """
     kernel = __salt__['grains.item']('os')  # pylint: disable=E0602,E0603
 
+    # Disable rebooting for HDP clusters until that works reliably
+    hadoop_distro = __salt__['pillar.get']('hadoop.distro')  # pylint: disable=E0602,E0603
+    if hadoop_distro == 'HDP':
+        return False
+
     if kernel['os'] == "CentOS" or kernel['os'] == "RedHat":
         try:
             current_version = __salt__['cmd.run']('uname -r')  # pylint: disable=E0602,E0603

--- a/salt/hdp/files/hdp_setup.py
+++ b/salt/hdp/files/hdp_setup.py
@@ -20,7 +20,7 @@ DEFAULT_LOG_FILE = '/var/log/pnda/hadoop_setup.log'
 PNDA_BLUEPRINT_NAME = "pnda-blueprint"
 
 logging.basicConfig(filename=DEFAULT_LOG_FILE,
-                    level=logging.INFO,
+                    level=logging.DEBUG,
                     format='%(asctime)s - %(levelname)s - %(message)s')
 
 def wait_on_cmd(tracking_uri, msg, auth, headers):

--- a/salt/hdp/httpfs.sls
+++ b/salt/hdp/httpfs.sls
@@ -11,6 +11,7 @@ hdp-httpfs_pkg:
   pkg.installed:
     - name: hadoop-httpfs
     - ignore_epoch: True
+    - skip_verify: True
 
 hdp-httpfs_create_link:
   file.symlink:


### PR DESCRIPTION
Plus a couple of minor changes for HDP clusters:
 - don't verify the hadoop-https deb package, this needs revisiting to fix properly with the package being authenticated.
 - enable hdp_setup debug to try and capture a problem I saw once with hdp_setup not waiting for installation to complete before existing