### PR TITLE
PNDA-3238: Add jupyter extensions to the kenel virtual environment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3343: When expanding a cluster new datanodes are given a spark gateway role
 - PNDA-3309: Write `CM_SETUP_SUCCESS` into a fixed directory
 - PNDA-3369: fix issue on offsets topic replication factor on kafka configuration zhere default value is 3
+- PNDA-3238: Add jupyter extensions to the kenel virtual environment.
 
 ## [2.0.0] 2017-05-23
 ### Added

--- a/pillar/packages/RedHat.sls
+++ b/pillar/packages/RedHat.sls
@@ -54,6 +54,10 @@ libtirpc-devel:
 libsasl:
   package-name: libgsasl-devel
   version: ""
+libxml2:
+  package-name: libxml2-devel
+libxslt:
+  package-name: libxslt-devel
 mysql-server:
   package-name: mysql-community-server
   version: "5.5.54-2.el7"

--- a/pillar/packages/Ubuntu.sls
+++ b/pillar/packages/Ubuntu.sls
@@ -42,6 +42,11 @@ libffi-dev:
 libsasl:
   package-name: libsasl2-dev
   version: ""
+libxml2:
+  package-name: libxml2-dev
+  version: ""
+libxslt:
+  package-name: libxslt-dev
 mysql-server:
   package-name: mysql-server-5.6
   version: "5.6.33-0ubuntu0.14.04.1"

--- a/salt/jupyter/extensions.sls
+++ b/salt/jupyter/extensions.sls
@@ -1,5 +1,4 @@
 ## Install Jupyter Spark extension ##
-
 {% set pnda_home_directory = pillar['pnda']['homedir'] %}
 {% set virtual_env_dir = pnda_home_directory + '/jupyter' %}
 {% set pip_index_url = pillar['pip']['index_url'] %}
@@ -11,11 +10,8 @@
 {% set extensions_package = 'jupyter-spark-0.3.0-patch.tar.gz' %}
 {% set extensions_url = mirror_location + extensions_package %}
 
-jupyter-extension-enable_widget_nbextensions:
-  cmd.run:
-    - name: {{ virtual_env_dir }}/bin/jupyter nbextension enable --py widgetsnbextension --system
-    - unless: |
-        {{ virtual_env_dir }}/bin/jupyter nbextension list --system|grep 'jupyter-spark/extension.*enabled'
+include:
+  - python-pip
 
 jupyter-pip-requirements:
   file.managed:
@@ -29,9 +25,24 @@ jupyter-pip-requirements:
 jupyter-extension_install_jupyter_spark:
   pip.installed:
     - requirements: {{ virtual_env_dir }}/requirements-jupyter-extensions.txt
-    - python: python3
     - index_url: {{ pip_index_url }}
-    - bin_env: {{ virtual_env_dir }}
+    - bin_env: {{ virtual_env_dir }}/bin/pip3
+
+jupyter-extension-packages:
+  pkg.installed:
+    - pkgs: 
+      - {{ pillar['libxml2']['package-name'] }}
+      - {{ pillar['libxslt']['package-name'] }}
+
+jupyter-extension-create-venv:
+  virtualenv.managed:
+    - name: {{ pnda_home_directory }}/jupyter-extensions
+    - requirements: {{ virtual_env_dir }}/requirements-jupyter-extensions.txt
+    - python: python2
+    - index_url: {{ pip_index_url }}
+    - require:
+      - pip: python-pip-install_python_pip
+      - pkg: jupyter-extension-packages
 
 jupyter-extension_jupyter_spark:
   cmd.run:
@@ -45,4 +56,4 @@ jupyter-extension_jupyter_spark:
         {{ virtual_env_dir }}/bin/jupyter nbextension list --system|grep 'jupyter-spark/extension.*enabled' &&
         {{ virtual_env_dir }}/bin/jupyter nbextension list --system|grep 'jupyter-js-widgets/extension.*enabled'
     - require:
-      - pip: jupyter-extension_install_jupyter_spark
+      - virtualenv: jupyter-extension-create-venv

--- a/salt/jupyter/files/requirements-jupyter.txt
+++ b/salt/jupyter/files/requirements-jupyter.txt
@@ -32,4 +32,4 @@ testpath==0.3
 tornado==4.4.2
 traitlets==4.3.1
 wcwidth==0.1.7
-widgetsnbextension==1.2.6
+widgetsnbextension==2.0.0

--- a/salt/jupyter/jupyter.sls
+++ b/salt/jupyter/jupyter.sls
@@ -3,6 +3,7 @@
 {% set pip_index_url = pillar['pip']['index_url'] %}
 {% set jupyter_kernels_dir = '/usr/local/share/jupyter/kernels' %}
 {% set app_packages_home = pnda_home_directory + '/app-packages' %}
+{% set jupyter_extension_venv = pnda_home_directory + '/jupyter-extensions' %}
 {% set pnda_user  = pillar['pnda']['user'] %}
 
 {% if pillar['hadoop.distro'] == 'HDP' %}
@@ -83,6 +84,7 @@ jupyter-copy_pyspark_kernel:
         spark_home: {{ spark_home }}
         hadoop_conf_dir: {{ hadoop_conf_dir }}
         app_packages_home: {{ app_packages_home }}
+        jupyter_extension_venv: {{ jupyter_extension_venv }}
 
 #copy data-generator.py script
 jupyter-copy_data_generator_script:

--- a/salt/jupyter/templates/pyspark_kernel.json.tpl
+++ b/salt/jupyter/templates/pyspark_kernel.json.tpl
@@ -12,7 +12,7 @@
   "HADOOP_CONF_DIR":"{{ hadoop_conf_dir }}",
   "PYSPARK_PYTHON":"{{ anaconda_home }}/bin/python",
   "SPARK_HOME": "{{ spark_home }}",
-  "PYTHONPATH": "{{ app_packages_home }}/lib/python2.7/site-packages:{{ spark_home }}/python:{{ spark_home }}/python/lib/py4j-0.9-src.zip",
+  "PYTHONPATH": "{{ app_packages_home }}/lib/python2.7/site-packages:{{ jupyter_extension_venv }}/lib/python2.7/site-packages:{{ spark_home }}/python:{{ spark_home }}/python/lib/py4j-0.9-src.zip",
   "PYTHONSTARTUP": "{{ spark_home }}/python/pyspark/shell.py",
   "PYSPARK_SUBMIT_ARGS": "--master yarn-client --jars {{ spark_home }}/lib/spark-examples.jar pyspark-shell"
  }

--- a/salt/jupyter/templates/requirements-jupyter-extensions.txt.tpl
+++ b/salt/jupyter/templates/requirements-jupyter-extensions.txt.tpl
@@ -1,3 +1,4 @@
 {{ extensions_url }}
 lxml==3.6.4
 ipywidgets==6.0.0
+widgetsnbextension==2.0.0


### PR DESCRIPTION
The jupyter extensions (like lxml, ipywidet, ...) need to be installed
on both the client side and the kernel side.
See documentation @:
- http://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Custom.html
- https://pypi.python.org/pypi/jupyter-spark/0.3.0

Depends on the pull request in the pnda repo.