### PR TITLE
Remove recursive chmod for user directory.

### DIFF
--- a/salt/pnda/user.sls
+++ b/salt/pnda/user.sls
@@ -25,5 +25,3 @@ pnda-set_home_dir_perms:
   file.directory:
     - name: {{ pnda_home_directory }}
     - mode: 755
-    - recurse:
-      - mode


### PR DESCRIPTION
This recursive chmod is not idempotent and overwrites identity files
permissions (amongst other) stored in that directory.