### PR TITLE
PNDA 2390: PNDA restarts any services that need restarting when rebooted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - PNDA-3330: Add default application user configuration to the deployment manager.
 - PNDA-2389: PNDA automatically reboots instances that need rebooting following kernel updates
+- PNDA 2390: PNDA restarts any services that need restarting when rebooted
 - PNDA-2982: Added support for adding pyspark application dependencies
 - PNDA-1960: Make Kafkat available on nodes as option for Kafka management at CLI
 - PNDA-2445: Support for Hortonworks HDP hadoop distro

--- a/salt/_beacons/service_restart.py
+++ b/salt/_beacons/service_restart.py
@@ -1,26 +1,78 @@
-# Import python libs
 """
   To monitor pnda service status
 """
 from __future__ import absolute_import
 
 import logging
-
-LOGGER = logging.getLogger(__name__)
+# retry the start service only for every DOWN_COUNT_MAX
+DOWN_COUNT_MAX = 5
+# maximum retry count is RETRY_COUNT_MAX
+RETRY_COUNT_MAX = 10
+# retry_count will reset after RETRY_COUNT_MAX
+RETRY_COUNT_RESET = 10
 
 
 def beacon(config):# pylint: disable=W0612,W0613
     """
       Beacons let you use the Salt event system to monitor non-Salt processes
     """
+    logging.error("enter beacon")
+    hadoop_distro = __salt__['pnda.hadoop_distro']()# pylint: disable=E0602,E0603
+    cluster_name = __salt__['pnda.cluster_name']()# pylint: disable=E0602,E0603
     ret_dict = dict()
     ret = list()
-    result = __salt__['pnda_service_restart.managehadoopclusterrestart']()# pylint: disable=E0602,E0603
+    if hadoop_distro == 'CDH' :
+      result = __salt__['pnda_service_restart.managehadoopclusterrestart']()# pylint: disable=E0602,E0603
+      if result:
+        ret_dict['tag'] = 'service/hadoop/status/restarted'
+      else:
+        ret_dict['tag'] = 'service/hadoop/status/failed'
+        ret.append(ret_dict)
+      return ret
 
-    if result:
-        ret_dict['Restarted'] = True
-        ret.append(ret_dict)
-    else:
-        ret_dict['Restarted'] = False
-        ret.append(ret_dict)
+    #HDP Config
+    servicelist = __salt__['grains.get']('serviceList')  # pylint: disable=E0602,E0603
+    if not servicelist:
+       servicelist = {'up_count': 0,'down_count': 0,'retry_count': 0}
+
+    health_report =__salt__['pnda.ambari_get_cluster_health_report']()# pylint: disable=E0602,E0603
+    if (health_report['Host/host_status/HEALTHY']  !=
+        health_report['Host/host_state/HEALTHY']):
+        servicelist['down_count'] += 1
+        if servicelist['retry_count'] > RETRY_COUNT_MAX:
+            ret_dict['tag'] = 'service/hadoop/status/maxRetryreached'
+        elif servicelist['down_count'] < DOWN_COUNT_MAX:
+            ret_dict['tag'] = 'service/hadoop/status/downcount'
+        else:
+            ret_dict['tag'] = 'service/hadoop/status/stopped'
+            servicelist['retry_count'] += 1
+            servicelist['down_count'] = 0
+    else :
+        ret_dict['tag'] = 'service/hadoop/status/running'
+        servicelist['up_count'] += 1
+        if servicelist['up_count'] > RETRY_COUNT_RESET:
+           servicelist['retry_count'] = 0
+    ret.append(ret_dict)
+    logging.error(servicelist)
+
+    __salt__['grains.set']("serviceList", {}, True)  # pylint: disable=E0602,E0603
+    __salt__['grains.set'](  # pylint: disable=E0602,E0603
+        "serviceList", servicelist, True)
+    ##Ambari Addon service Check
+    #get hostname
+    for host in __salt__['pnda.get_hosts_by_role']('HBASE','HBASE_MASTER'):
+        ret_dict = dict()
+        res = __salt__['network.connect'](host,'20550')['result']
+        if not res:
+           ret_dict['tag'] = 'service/hadoop/addon/status/stopped'
+           ret_dict['target'] = host
+           ret_dict['service'] = 'hbase_rest'
+           ret.append(ret_dict)
+        ret_dict = dict()
+        res = __salt__['network.connect'](host,'9090')['result']
+        if not res:
+           ret_dict['tag'] = 'service/hadoop/addon/status/stopped'
+           ret_dict['target'] = host
+           ret_dict['service'] = 'hbase_thrift'
+           ret.append(ret_dict)
     return ret

--- a/salt/_modules/kernel_reboot.py
+++ b/salt/_modules/kernel_reboot.py
@@ -5,26 +5,29 @@ Module for to check system reboot
 # Import python libs
 from __future__ import absolute_import
 from subprocess import Popen
+import requests
+import time
+import logging
+import socket
+import re
 
+logging.basicConfig(level=logging.DEBUG)
+LOGGER = logging.getLogger(__name__)
 
 def reboot():
     """Issue a system reboot command (after a minute) , and retrun control to salt master """
-    if not required():
-        return "Kernel reboot not required"
     cmd_str = 'shutdown -r +1 "Server is going down for kernel upgrade"'
+
+    if not required():
+        __salt__['cmd.run']("service salt-minion restart")
+        return "Kernel reboot not required"
     Popen([cmd_str], shell=True, stdin=None,
           stdout=None, stderr=None, close_fds=True)
     return cmd_str
 
-
 def required():
     """ returns system needs reboot required or not """
     kernel = __salt__['grains.item']('os')  # pylint: disable=E0602,E0603
-
-    # Disable rebooting for HDP clusters until that works reliably
-    hadoop_distro = __salt__['pillar.get']('hadoop.distro')  # pylint: disable=E0602,E0603
-    if hadoop_distro == 'HDP':
-        return False
 
     if kernel['os'] == "CentOS" or kernel['os'] == "RedHat":
         try:
@@ -41,3 +44,4 @@ def required():
         return True
 
     return __salt__['file.file_exists']('/var/run/reboot-required')  # pylint: disable=E0602,E0603
+

--- a/salt/_modules/pnda.py
+++ b/salt/_modules/pnda.py
@@ -173,3 +173,7 @@ def ambari_get_service_status(service):
     service_resp = response.json()
 
     return service_resp['ServiceInfo']['state']
+
+def ambari_get_cluster_health_report():
+    health_report = ambari_request('/clusters/'+cluster_name())
+    return health_report['Clusters']['health_report']

--- a/salt/_modules/pnda_service_restart.py
+++ b/salt/_modules/pnda_service_restart.py
@@ -245,6 +245,7 @@ def startservice(connection_object, service_name, role_name, node_name):
             cluster_name = cluster_detail.name
             break
         cluster_manager = connection_object.get_cluster(cluster_name)
+        status, message = wait_on_command([cluster_manager.start()])
         for service in cluster_manager.get_all_services():
             if service_name != service.type:
                 continue

--- a/salt/_states/hadoop_service.py
+++ b/salt/_states/hadoop_service.py
@@ -1,0 +1,165 @@
+'''
+Module for to check system reboot
+'''
+
+# Import python libs
+from __future__ import absolute_import
+from subprocess import Popen
+import requests
+import time
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+LOGGER = logging.getLogger(__name__)
+def stop(name):
+    ret = {
+        'name': name,
+        'changes': {},
+        'result': False,
+        'comment': '',
+        'pchanges': {},
+    }
+    hadoop_distro = __salt__['pillar.get']('hadoop.distro')  # pylint: disable=E0602,E0603
+    if hadoop_distro == 'HDP':
+        result = ambari_stop_all_services()
+    else:
+        result= cloudera_stop_all_services()
+
+    ret['result'] = result
+    return ret
+
+def start(name):
+    ret = {
+        'name': name,
+        'changes': {},
+        'result': False,
+        'comment': '',
+        'pchanges': {},
+    }
+    hadoop_distro = __salt__['pillar.get']('hadoop.distro')  # pylint: disable=E0602,E0603
+    if hadoop_distro == 'HDP':
+        result = ambari_start_all_services()
+    else:
+        result= True
+        ret['comment'] = "CDH not implemented"
+
+    ret['result'] = result
+    return ret
+def cloudera_stop_all_services():
+    cm_host = __salt__['pnda.hadoop_manager_ip']()  # pylint: disable=E0602,E0603
+    cm_user = __salt__['pnda.hadoop_manager_username']()  # pylint: disable=E0602,E0603
+    cm_pass = __salt__['pnda.hadoop_manager_password']()  # pylint: disable=E0602,E0603
+    cm_name = __salt__['pnda.cluster_name']()  # pylint: disable=E0602,E0603
+    headers = {'X-Requested-By': cm_user}
+    auth = (cm_user, cm_pass)
+    full_uri = 'http://%s:7180/api/v17/clusters/%s/commands/stop' % (cm_host,cm_name)
+    response = requests.post(full_uri, auth=auth, headers=headers)
+    if response.status_code != 200:
+        return False
+    response = response.json()
+    cmd_id = response['id']
+
+    full_uri = 'http://%s:7180/api/v17/commands/%s' % (cm_host,cmd_id)
+    response = requests.get(full_uri, auth=auth)
+    if response.status_code != 200:
+        return False
+    response = response.json()
+    while response['active'] is True and response.get('success',None) is None:
+        time.sleep(5)
+        response = requests.get(full_uri, auth=auth)
+        if response.status_code != 200:
+            return False
+        response = response.json()
+    resultMessage = response.get('resultMessage',None)
+    if response.get('success',None) is False:
+        LOGGER.error('%s (cmd.success is False)' % resultMessage)
+        return False
+    elif response.get('success',None) is None:
+        LOGGER.error('%s (cmd.success is None)' % resultMessage)
+        return false
+    elif response.get('success',None) is True:
+        LOGGER.info('%s (Cluster stopped succeefully)' % resultMessage)
+    return True
+
+def ambari_stop_all_services():
+    cluster_name = __salt__['pnda.cluster_name']()  # pylint: disable=E0602,E0603
+    stop_command = '''{
+            "RequestInfo": {
+                "context": "_PARSE_.STOP.ALL_SERVICES",
+                "operation_level": {
+                    "level": "CLUSTER",
+                    "cluster_name": "%s"
+                }
+            },
+            "Body": {
+                "ServiceInfo": {
+                    "state": "INSTALLED"
+                }
+            }
+    }''' % cluster_name
+
+    response = ambari_request('/clusters/%s/services' % (cluster_name), stop_command)
+    if response is not None:
+        return ambari_wait_on_cmd( response['href'], 'services to be stopped by Ambari')
+    return False
+
+def ambari_start_all_services():
+    cluster_name = __salt__['pnda.cluster_name']()  # pylint: disable=E0602,E0603
+    stop_command = '''{
+            "RequestInfo": {
+                "context": "_PARSE_.START.ALL_SERVICES",
+                "operation_level": {
+                    "level": "CLUSTER",
+                    "cluster_name": "%s"
+                }
+            },
+            "Body": {
+                "ServiceInfo": {
+                    "state": "STARTED"
+                }
+            }
+    }''' % cluster_name
+
+    response = ambari_request('/clusters/%s/services' % (cluster_name), stop_command)
+    if response is not None:
+        return ambari_wait_on_cmd( response['href'], 'services to be stopped by Ambari')
+    return False
+
+def ambari_wait_on_cmd(tracking_uri, msg):
+    LOGGER.info('Waiting for %s...', msg)
+    progress_percent = 0
+    while progress_percent < 100:
+        time.sleep(5)
+        status_reponse = ambari_request(tracking_uri)
+        LOGGER.debug(status_reponse['Requests'])
+        cmd_status = status_reponse['Requests']['request_status']
+        progress_percent = int(status_reponse['Requests']['progress_percent'])
+        LOGGER.info('Progress for %s: %s%% - %s', tracking_uri, progress_percent, cmd_status)
+    if cmd_status == 'COMPLETED':
+        return True
+    return False
+
+def ambari_request(uri,body=None):
+    cm_host = __salt__['pnda.hadoop_manager_ip']()  # pylint: disable=E0602,E0603
+    cm_user = __salt__['pnda.hadoop_manager_username']()  # pylint: disable=E0602,E0603
+    cm_pass = __salt__['pnda.hadoop_manager_password']()  # pylint: disable=E0602,E0603
+
+    headers = {'X-Requested-By': cm_user}
+    auth = (cm_user, cm_pass)
+    if uri.startswith("http"):
+        full_uri = uri
+    else:
+        full_uri = 'http://%s:8080/api/v1%s' % (cm_host, uri)
+
+
+    if body is None:
+        response = requests.get(full_uri, auth=auth, headers=headers)
+    else:
+        response = requests.put(full_uri, body, auth=auth, headers=headers)
+    LOGGER.debug('Response to command = %s', response.status_code)
+    LOGGER.debug(response.text)
+    try:
+        return response.json()
+    except ValueError:
+        return None
+

--- a/salt/hdp/service.sls
+++ b/salt/hdp/service.sls
@@ -1,0 +1,2 @@
+hdp-Restart_HDP_services:
+  hadoop_service.start

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -238,6 +238,22 @@ orchestrate-pnda-install_remove_new_node_markers:
     - timeout: 120
     - queue: True
 
+orchestrate-saltstack_beacon_config:
+  salt.state:
+    - tgt: '*'
+    - tgt_type: compound
+    - sls: reboot.beacon
+    - timeout: 120
+    - queue: True
+
+orchestrate-pnda_hadoop_service_stop:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@roles:hadoop_manager'
+    - tgt_type: compound
+    - sls: reboot.hadoop_service_stop
+    - timeout: 120
+    - queue: True
+
 orchestrate-pnda_kernel_reboot:
   salt.state:
     - tgt: '*'

--- a/salt/reactor/service_hadoop_addon_start_entry.sls
+++ b/salt/reactor/service_hadoop_addon_start_entry.sls
@@ -1,0 +1,14 @@
+{% if data['data']['service'] == 'hbase_thrift' %}
+reactor-hadoop_service_addon_start:
+  local.cmd.run:
+    - tgt: {{ data['data']['target'] }}
+    - arg:
+      - /usr/hdp/current/hbase-master/bin/hbase-daemon.sh start thrift -p 9090 --infoport 9091
+{% endif %}
+{% if data['data']['service'] == 'hbase_rest' %}
+reactor-hadoop_service_addon_start:
+  local.cmd.run:
+    - tgt: {{ data['data']['target'] }}
+    - arg:
+      - /usr/hdp/current/hbase-master/bin/hbase-daemon.sh start rest -p 20550 --infoport 20551
+{% endif %}

--- a/salt/reactor/service_hadoop_start_entry.sls
+++ b/salt/reactor/service_hadoop_start_entry.sls
@@ -1,0 +1,7 @@
+reactor-hadoop_service_start:
+  local.state.sls:
+    - arg:
+      - hdp.service
+    - tgt: {{ data['data']['id'] }}
+    - timeout: 120
+    - queue: True

--- a/salt/reboot/beacon.sls
+++ b/salt/reboot/beacon.sls
@@ -1,0 +1,19 @@
+{% set roles = salt['grains.get']('roles', '') %}
+reboot-beacon_create_conf_file:
+  file.managed:
+    - name: /etc/salt/minion.d/beacons.conf
+    - contents: 
+      - "beacons:"
+      - "  kernel_reboot_required:"
+      - "    interval: 30"
+      - "    disable_during_state_run: True"
+{% if 'hadoop_manager' in roles %}
+      - "  service_restart:"
+      - "    interval: 30"
+      - "    disable_during_state_run: True"
+{% endif %}
+{% if 'opentsdb' in roles %}
+      - "  service_opentsdb:"
+      - "    interval: 30"
+      - "    disable_during_state_run: True"
+{% endif %}

--- a/salt/reboot/hadoop_service_stop.sls
+++ b/salt/reboot/hadoop_service_stop.sls
@@ -1,0 +1,2 @@
+reboot-stop_hadoop_service:
+  hadoop_service.stop


### PR DESCRIPTION
Problem Statement:

PNDA 2390: PNDA restarts any services that need restarting when rebooted

Analysis:

Hadoop services are down due to node reboot or other issues
Services once down needs user intervention to start services
Need to automate the start process

Change:

Fix supports for Ambari (HDP distribution)
implemented the Beacon and reactor method to implement the fix
moved beacon entry from aws-template to SaltStack
Fix for kernel reboot user story (PNDA-2389)