### PR TITLE
PNDA-3432: Jupyter not launching after reboot.

### DIFF
--- a/salt/pnda/user.sls
+++ b/salt/pnda/user.sls
@@ -5,7 +5,13 @@
 
 {% if grains['os'] == 'RedHat' %}
 permissive:
-    selinux.mode
+  selinux.mode: []
+  file.replace:
+    - name: '/etc/selinux/config'
+    - pattern: '^SELINUX=(?!\s*permissive).*'
+    - repl: 'SELINUX=permissive'
+    - append_if_not_found: True
+    - show_changes: True
 {% endif %}
 
 pnda-create_pnda_user:


### PR DESCRIPTION
This is due to selinux permissive setting not being persisted.
In Salt version 2015.8, selinux.mode is not persisted. So a
file.replace is being added to persist the mode.