### PR TITLE
PNDA-3432: Jupyter not launching after reboot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3309: Write `CM_SETUP_SUCCESS` into a fixed directory
 - PNDA-3369: fix issue on offsets topic replication factor on kafka configuration zhere default value is 3
 - PNDA-3238: Add jupyter extensions to the kenel virtual environment.
+- PNDA-3432: Jupyter not launching after reboot on RHEL.
 
 ## [2.0.0] 2017-05-23
 ### Added

--- a/salt/pnda/user.sls
+++ b/salt/pnda/user.sls
@@ -5,7 +5,13 @@
 
 {% if grains['os'] == 'RedHat' %}
 permissive:
-    selinux.mode
+  selinux.mode: []
+  file.replace:
+    - name: '/etc/selinux/config'
+    - pattern: '^SELINUX=(?!\s*permissive).*'
+    - repl: 'SELINUX=permissive'
+    - append_if_not_found: True
+    - show_changes: True
 {% endif %}
 
 pnda-create_pnda_user:


### PR DESCRIPTION
This is due to selinux permissive setting not being persisted.
In Salt version 2015.8, selinux.mode is not persisted. So a
file.replace is being added to persist the mode.