### PR TITLE
PNDA-3013 Fix for Keystone passwords with illegal XML characters 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3238: Add jupyter extensions to the kenel virtual environment.
 - PNDA-3350: Fix dm.pem permission post deployment highstate.
 - PNDA-3432: Jupyter not launching after reboot on RHEL.
+- PNDA-3013: Fix issue on Keystone passwords with illegal XML characters (such as &) cause Hadoop setup to fail.
 
 ## [2.0.0] 2017-05-23
 ### Added

--- a/salt/cdh/templates/cfg_bmstandard.py.tpl
+++ b/salt/cdh/templates/cfg_bmstandard.py.tpl
@@ -155,11 +155,11 @@ MAPRED_CFG = {
 
 SWIFT_CONFIG = """\r\n<property><name>fs.swift.impl</name><value>org.apache.hadoop.fs.swift.snative.SwiftNativeFileSystem</value></property>
                   \r\n<property><name>fs.swift.service.pnda.auth.url</name><value>{{ keystone_auth_url }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.username</name><value>{{ keystone_user }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.tenant</name><value>{{ keystone_tenant }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.region</name><value>{{ region }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.username</name><value>{{ keystone_user|e }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.tenant</name><value>{{ keystone_tenant|e }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.region</name><value>{{ region|e }}</value></property>
                   \r\n<property><name>fs.swift.service.pnda.public</name><value>true</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.password</name><value>{{ keystone_password }}</value></property>"""
+                  \r\n<property><name>fs.swift.service.pnda.password</name><value>{{ keystone_password|e }}</value></property>"""
 
 S3_CONFIG = """\r\n<property><name>fs.s3a.access.key</name><value>{{ aws_key }}</value></property>
                \r\n<property><name>fs.s3a.secret.key</name><value>{{ aws_secret_key }}</value></property>"""

--- a/salt/cdh/templates/cfg_pico.py.tpl
+++ b/salt/cdh/templates/cfg_pico.py.tpl
@@ -213,11 +213,11 @@ MAPRED_CFG = {
 
 SWIFT_CONFIG = """\r\n<property><name>fs.swift.impl</name><value>org.apache.hadoop.fs.swift.snative.SwiftNativeFileSystem</value></property>
                   \r\n<property><name>fs.swift.service.pnda.auth.url</name><value>{{ keystone_auth_url }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.username</name><value>{{ keystone_user }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.tenant</name><value>{{ keystone_tenant }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.region</name><value>{{ region }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.username</name><value>{{ keystone_user|e }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.tenant</name><value>{{ keystone_tenant|e }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.region</name><value>{{ region|e }}</value></property>
                   \r\n<property><name>fs.swift.service.pnda.public</name><value>true</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.password</name><value>{{ keystone_password }}</value></property>"""
+                  \r\n<property><name>fs.swift.service.pnda.password</name><value>{{ keystone_password|e }}</value></property>"""
 
 S3_CONFIG = """\r\n<property><name>fs.s3a.access.key</name><value>{{ aws_key }}</value></property>
                \r\n<property><name>fs.s3a.secret.key</name><value>{{ aws_secret_key }}</value></property>"""

--- a/salt/cdh/templates/cfg_production.py.tpl
+++ b/salt/cdh/templates/cfg_production.py.tpl
@@ -177,11 +177,11 @@ MAPRED_CFG = {
 
 SWIFT_CONFIG = """\r\n<property><name>fs.swift.impl</name><value>org.apache.hadoop.fs.swift.snative.SwiftNativeFileSystem</value></property>
                   \r\n<property><name>fs.swift.service.pnda.auth.url</name><value>{{ keystone_auth_url }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.username</name><value>{{ keystone_user }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.tenant</name><value>{{ keystone_tenant }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.region</name><value>{{ region }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.username</name><value>{{ keystone_user|e }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.tenant</name><value>{{ keystone_tenant|e }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.region</name><value>{{ region|e }}</value></property>
                   \r\n<property><name>fs.swift.service.pnda.public</name><value>true</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.password</name><value>{{ keystone_password }}</value></property>"""
+                  \r\n<property><name>fs.swift.service.pnda.password</name><value>{{ keystone_password|e }}</value></property>"""
 
 S3_CONFIG = """\r\n<property><name>fs.s3a.access.key</name><value>{{ aws_key }}</value></property>
                \r\n<property><name>fs.s3a.secret.key</name><value>{{ aws_secret_key }}</value></property>"""

--- a/salt/cdh/templates/cfg_standard.py.tpl
+++ b/salt/cdh/templates/cfg_standard.py.tpl
@@ -155,11 +155,11 @@ MAPRED_CFG = {
 
 SWIFT_CONFIG = """\r\n<property><name>fs.swift.impl</name><value>org.apache.hadoop.fs.swift.snative.SwiftNativeFileSystem</value></property>
                   \r\n<property><name>fs.swift.service.pnda.auth.url</name><value>{{ keystone_auth_url }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.username</name><value>{{ keystone_user }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.tenant</name><value>{{ keystone_tenant }}</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.region</name><value>{{ region }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.username</name><value>{{ keystone_user|e }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.tenant</name><value>{{ keystone_tenant|e }}</value></property>
+                  \r\n<property><name>fs.swift.service.pnda.region</name><value>{{ region|e }}</value></property>
                   \r\n<property><name>fs.swift.service.pnda.public</name><value>true</value></property>
-                  \r\n<property><name>fs.swift.service.pnda.password</name><value>{{ keystone_password }}</value></property>"""
+                  \r\n<property><name>fs.swift.service.pnda.password</name><value>{{ keystone_password|e }}</value></property>"""
 
 S3_CONFIG = """\r\n<property><name>fs.s3a.access.key</name><value>{{ aws_key }}</value></property>
                \r\n<property><name>fs.s3a.secret.key</name><value>{{ aws_secret_key }}</value></property>"""


### PR DESCRIPTION
Problem Statement:
=================
PNDA-3013: Keystone passwords with illegal XML characters (such as &) cause Hadoop setup to fail.

Analysis:
=========
If keystone_password contains any special characters (>, <, &, or "), Hadoop setup will fail because, in jinja template, these special characters are escaped.
By default, jinja2 does not escape the special characters.
NOTE: The same issue will also cause setup to fail if special characters in keystone_username,keystone_tenant and region.

Solution:
========
Fix : Esacping of keystone_password, keystone_user, keystone_tenant and region by piping the variable through the |e filter.

Files Changed :
===============
 salt/cdh/templates/cfg_pico.py.tpl
 salt/cdh/templates/cfg_standard.py.tpl
 salt/cdh/templates/cfg_bmstandard.py.tpl
 salt/cdh/templates/cfg_production.py.tpl

Tests:
===============
1. Deploy PNDA for PICO flavour for ubuntu CDH.
2. Deploy PNDA for PICO flavour for RHEL CDH.
3. Deploy PNDA for STANDARD flavour for RHEL CDH.