### PR TITLE
Set Hadoop heap sizes for production flavor

### DIFF
--- a/salt/hdp/templates/cfg_production.py.tpl
+++ b/salt/hdp/templates/cfg_production.py.tpl
@@ -14,7 +14,7 @@ BLUEPRINT = r'''{
                     "timeline.metrics.skip.disk.metrics.patterns" : "true",
                     "ambari_metrics_user" : "ams",
                     "metrics_monitor_log_dir" : "/var/log/pnda/ambari-metrics-monitor",
-                    "metrics_collector_heapsize" : "512",
+                    "metrics_collector_heapsize" : "1024",
                     "failover_strategy_blacklisted_interval" : "300",
                     "metrics_collector_pid_dir" : "/var/run/ambari-metrics-collector",
                     "metrics_collector_log_dir" : "/var/log/pnda/ambari-metrics-collector",
@@ -109,7 +109,9 @@ BLUEPRINT = r'''{
         {
             "ams-hbase-env" : {
                 "properties" : {
-                    "hbase_log_dir" : "/var/log/pnda/ambari-metrics-collector"
+                    "hbase_log_dir" : "/var/log/pnda/ambari-metrics-collector",
+                    "hbase_master_heapsize": "8192",
+                    "hbase_regionserver_heapsize" : "20480"
                 }
             }
         },
@@ -129,7 +131,8 @@ BLUEPRINT = r'''{
             "yarn-env" : {
                 "properties" : {
                     "yarn_log_dir_prefix" : "/var/log/pnda/hadoop-yarn",
-                    "resourcemanager_heapsize" : "4096"
+                    "resourcemanager_heapsize" : "4096",
+                    "nodemanager_heapsize": "4096"
                 }
             }
         },
@@ -181,9 +184,17 @@ BLUEPRINT = r'''{
             }
         },
         {
+            "mapred-env":{
+                "properties": {
+                    "jobhistory_heapsize": "8192"
+                }
+            }
+        },
+        {
             "zookeeper-env" : {
                 "properties" : {
-                    "zk_log_dir" : "/var/log/pnda/zookeeper"
+                    "zk_log_dir" : "/var/log/pnda/zookeeper",
+                    "zk_server_heapsize" : "2048"
                 }
             }
         },
@@ -201,7 +212,8 @@ BLUEPRINT = r'''{
                     "oozie_data_dir" : "/data0/var/lib/oozie/data",
                     "oozie_user" : "oozie",
                     "oozie_admin_users" : "{oozie_user}, oozie-admin",
-                    "oozie_database" : "Existing MySQL / MariaDB Database"
+                    "oozie_database" : "Existing MySQL / MariaDB Database",
+                    "oozie_heapsize": "4096m"
                 }
             }
         },
@@ -235,7 +247,18 @@ BLUEPRINT = r'''{
                     "javax.jdo.option.ConnectionURL" : "jdbc:mysql://%(cluster_name)s-hadoop-mgr-4/hive",
                     "javax.jdo.option.ConnectionUserName" : "hive",
                     "hive_log_dir" : "/var/log/pnda/hive",
-                    "hcat_log_dir" : "/var/log/pnda/webhcat"                }
+                    "hcat_log_dir" : "/var/log/pnda/webhcat",
+                    "hive.client.heapsize": "4096",
+                    "hive.heapsize": "16384",
+                    "hive.metastore.heapsize": "16384"
+                }
+            }
+        },
+        {
+            "hive-interactive-env": {
+                "properties": {
+                    "hive_heapsize": "16384"
+                }
             }
         },
         {
@@ -267,10 +290,14 @@ BLUEPRINT = r'''{
         {
             "hadoop-env" : {
                 "properties" : {
-                    "namenode_heapsize": "3072m",
-                    "namenode_opt_maxnewsize": "361m",
-                    "namenode_opt_newsize": "361m",
-                    "hdfs_log_dir_prefix" : "/var/log/pnda/hadoop"
+                    "namenode_heapsize": "16384m",
+                    "namenode_opt_maxnewsize": "2048m",
+                    "namenode_opt_newsize": "2048m",
+                    "namenode_opt_permsize": "128m",
+                    "namenode_opt_maxpermsize": "256m",
+                    "hdfs_log_dir_prefix": "/var/log/pnda/hadoop",
+                    "hadoop_heapsize": "2048",
+                    "dtnode_heapsize" : "2048m"
                 }
             }
         },


### PR DESCRIPTION
Please don't delete the branch, more tuning will
follow. This has been proven working this far on the
production mock cluster.