### PR TITLE
PNDA-1322: Test Master Dataset Health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3314: Added new flavor for larger PNDAs called "production"
 
 ### Changed
+- PNDA-1322: Test Master Dataset Health
 - PNDA-2965: Rename `cloudera_*` role grains to `hadoop_*`
 - PNDA-3216: Uprev to logstash 5.2.2
 - PNDA-3180: Limit orchestrate commands to new nodes only

--- a/salt/_modules/pnda.py
+++ b/salt/_modules/pnda.py
@@ -90,6 +90,10 @@ def kafka_zookeepers_ips():
     """Returns zookeeper ip addresses"""
     return ip_addresses('zookeeper')
 
+def data_service_ips():
+    """Returns data service ip addresses"""
+    return ip_addresses('data_service')
+
 def ldap_ip():
     """Returns the ip address of the LDAP server"""
     query = "G@roles:LDAP"

--- a/salt/gobblin/templates/mr.pull.test.tpl
+++ b/salt/gobblin/templates/mr.pull.test.tpl
@@ -48,3 +48,5 @@ metrics.reporting.file.enabled=true
 # Don't ingest the avro.internal.testbot topic as it's only an internal PNDA
 # testing topic
 topic.blacklist=__consumer_offsets
+# White list topic is used to check initial creation of Master Dataset
+topic.whitelist=avro.internal.testbot

--- a/salt/gobblin/templates/test-gobblin.conf.tpl
+++ b/salt/gobblin/templates/test-gobblin.conf.tpl
@@ -1,0 +1,13 @@
+description     "Linked-in Gobblin MRv2 application: PNDA pull"
+
+task
+
+umask 022
+setuid {{ gobblin_user }}
+
+env JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
+env HADOOP_BIN_DIR="{{ hadoop_home_bin }}"
+
+chdir {{ gobblin_directory_name }}
+
+exec bash ./bin/gobblin-mapreduce.sh --conf {{ gobblin_job_file }} --logdir /var/log/pnda/gobblin --workdir "{{ gobblin_work_dir }}" --jars $(ls lib/*.jar | tr '\n' ',')

--- a/salt/gobblin/templates/test-gobblin.service.tpl
+++ b/salt/gobblin/templates/test-gobblin.service.tpl
@@ -1,0 +1,10 @@
+[Unit]
+Description=Linked-in Gobblin MRv2 application: PNDA pull
+
+[Service]
+Type=oneshot
+UMask=022
+User=pnda
+Environment="JAVA_HOME=/usr/lib/jvm/java-8-oracle/" "HADOOP_BIN_DIR={{ hadoop_home_bin }}" "GOBBLIN_CONF_FILE=/opt/pnda/gobblin/configs/mr.pull.test" "GOBBLIN_LOG_DIR=/var/log/pnda/gobblin" "GOBBLIN_WORK_DIR=/user/pnda/gobblin/work" 'GOBBLIN_JARS=lib/*.jar'
+WorkingDirectory=/opt/pnda/gobblin/gobblin-dist
+ExecStart=/usr/bin/bash ./bin/gobblin-mapreduce.sh --conf $GOBBLIN_CONF_FILE --logdir $GOBBLIN_LOG_DIR --workdir $GOBBLIN_WORK_DIR --jars $GOBBLIN_JARS

--- a/salt/platform-testing/general.sls
+++ b/salt/platform-testing/general.sls
@@ -11,6 +11,7 @@
 {% set console_port = '3001' %}
 {% set zookeeper_port = '2181' %}
 {% set dm_port = '5000' %}
+{% set data_service_port = '7000' %}
 {% set opentsdb_port = '4242' %}
 
 {% set pnda_cluster = salt['pnda.cluster_name']() %}
@@ -28,6 +29,11 @@
 {%- set opentsdb_hosts = [] -%}
 {%- for ip in salt['pnda.opentsdb_ips']() -%}
 {%- do opentsdb_hosts.append(ip + ':' + opentsdb_port) -%}
+{%- endfor -%}
+
+{%- set data_service_host = [] -%}
+{%- for ip in salt['pnda.data_service_ips']() -%}
+{%- do data_service_host.append("http://" + ip + ':' + data_service_port) -%}
 {%- endfor -%}
 
 {%- set console_hosts = [] -%}
@@ -121,6 +127,8 @@ platform-testing-general-kafka_service:
       console_hosts: {{ console_hosts }}
       kafka_brokers: {{ kafka_brokers }}
       kafka_zookeepers: {{ kafka_zookeepers }}
+      data_service_host: {{ data_service_host }}
+      pnda_cluster: {{ pnda_cluster }}
 
 platform-testing-general-crontab-kafka:
   cron.present:

--- a/salt/platform-testing/templates/platform-testing-general-kafka.conf.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-kafka.conf.tpl
@@ -3,4 +3,4 @@ author      "PNDA team"
 start on runlevel [2345]
 task
 env PYTHON_HOME={{ platform_testing_directory }}/{{platform_testing_package}}/venv
-exec ${PYTHON_HOME}/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin kafka --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--brokerlist {{ kafka_brokers|join(',') }} --zkconnect {{ kafka_zookeepers|join(',') }} --prod2cons"
+exec ${PYTHON_HOME}/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin kafka --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--brokerlist {{ kafka_brokers|join(',') }} --zkconnect {{ kafka_zookeepers|join(',') }} --prod2cons --data_service {{ data_service_host|join(',') }} --cluster_name {{pnda_cluster }}"

--- a/salt/platform-testing/templates/platform-testing-general-kafka.service.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-kafka.service.tpl
@@ -3,4 +3,4 @@ Description=Platform testing general kafka
 
 [Service]
 Type=oneshot
-ExecStart={{ platform_testing_directory }}/{{platform_testing_package}}/venv/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin kafka --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--brokerlist {{ kafka_brokers|join(',') }} --zkconnect {{ kafka_zookeepers|join(',') }} --prod2cons"
+ExecStart={{ platform_testing_directory }}/{{platform_testing_package}}/venv/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin kafka --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--brokerlist {{ kafka_brokers|join(',') }} --zkconnect {{ kafka_zookeepers|join(',') }} --prod2cons --data_service {{ data_service_host|join(',') }} --cluster_name {{pnda_cluster }}"


### PR DESCRIPTION
# Problem Statement:
PNDA 1322: Test Master Dataset Health

# Analysis:
Check initial creation of dataset to track GOBBLIN Health.
Test Master Dataset Health by keeping track of HDFS directories/files created by GOBBLIN.

# Changes:
Modified gobblin Job configuration file(mr.pull) in salt. Kafka Test topic(avro.internal.testbot) has been removed from blacklist to test Master Dataset Health.
Modified Platform-testing in salt. Added two more inputs(data-service-ip and cluster-name) to KAFKA service to test dataset creation and it's health. 
Also modified KAFKA service and conf templates inside platform-testing templates directory to create a service file with new inputs.
Modified PNDA.py module to get data-service IP by giving it's role.
Added new GOBBLIN Job configuration file to test initial creation of dataset to track GOBBLIN Health. This Job configuration file will allow data only from TEST Topic(avro.internal.testbot)
To run with new Job configuraion, added service and conf templates in templates directory. 
Added a new step in gobblin init.sls state file to install these new service scripts.

# Test details:

Verified changes in AWS environment(OFFLINE/ONLINE):

UBUNTU-PICO-CDH
UBUNTU-STD-CDH
UBUNTU-PICO-HDP
UBUNTU-STD-HDP
RHEL-PICO-CDH
RHEL-STD-CDH
RHEL-PICO-HDP
RHEL-STD-HDP