### PR TITLE
Move yarn local dir to /data0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3380: Move opentsdb log to /var/log/pnda
 - PNDA-3441: Cleanup warnings from create_notebook_dir.sh script
 - PNDA-3451: Use existing MySQL for the Ambari database
+- PNDA-2486: Move yarn local directories to /data0 to separate the data from the operating system partition.
 
 ### Fixed
 - PNDA-3213: fix issue on wrong checksum file name for logserver sls

--- a/salt/cdh/templates/cfg_bmstandard.py.tpl
+++ b/salt/cdh/templates/cfg_bmstandard.py.tpl
@@ -124,7 +124,7 @@ MAPRED_CFG = {
             "config":
                 {
                     'yarn_nodemanager_heartbeat_interval_ms': 100,
-                    'yarn_nodemanager_local_dirs': '/var/yarn/nm',
+                    'yarn_nodemanager_local_dirs': '/data0/yarn/nm',
                     'yarn_nodemanager_log_dirs': '/var/log/pnda/hadoop-yarn/container',
                     'node_manager_log_dir': '/var/log/pnda/hadoop-yarn',
                     'yarn_nodemanager_resource_cpu_vcores': '14',

--- a/salt/cdh/templates/cfg_pico.py.tpl
+++ b/salt/cdh/templates/cfg_pico.py.tpl
@@ -160,7 +160,7 @@ MAPRED_CFG = {
             "config":
                 {
                     'yarn_nodemanager_heartbeat_interval_ms': 100,
-                    'yarn_nodemanager_local_dirs': '/var/yarn/nm',
+                    'yarn_nodemanager_local_dirs': '/data0/yarn/nm',
                     'yarn_nodemanager_log_dirs': '/var/log/pnda/hadoop-yarn/container',
                     'yarn_nodemanager_resource_cpu_vcores': '8',
                     'yarn_nodemanager_resource_memory_mb': '4096',

--- a/salt/cdh/templates/cfg_production.py.tpl
+++ b/salt/cdh/templates/cfg_production.py.tpl
@@ -140,7 +140,7 @@ MAPRED_CFG = {
             "config":
                 {
                     'yarn_nodemanager_heartbeat_interval_ms': 100,
-                    'yarn_nodemanager_local_dirs': '/var/yarn/nm',
+                    'yarn_nodemanager_local_dirs': '/data0/yarn/nm',
                     'yarn_nodemanager_log_dirs': '/var/log/pnda/hadoop-yarn/container',
                     'node_manager_log_dir': '/var/log/pnda/hadoop-yarn',
                     'yarn_nodemanager_resource_cpu_vcores': '48',

--- a/salt/cdh/templates/cfg_standard.py.tpl
+++ b/salt/cdh/templates/cfg_standard.py.tpl
@@ -124,7 +124,7 @@ MAPRED_CFG = {
             "config":
                 {
                     'yarn_nodemanager_heartbeat_interval_ms': 100,
-                    'yarn_nodemanager_local_dirs': '/var/yarn/nm',
+                    'yarn_nodemanager_local_dirs': '/data0/yarn/nm',
                     'yarn_nodemanager_log_dirs': '/var/log/pnda/hadoop-yarn/container',
                     'node_manager_log_dir': '/var/log/pnda/hadoop-yarn',
                     'yarn_nodemanager_resource_cpu_vcores': '7',

--- a/salt/hdp/templates/cfg_pico.py.tpl
+++ b/salt/hdp/templates/cfg_pico.py.tpl
@@ -139,6 +139,8 @@ BLUEPRINT = r'''{
             "yarn-site" : {
                 "properties" : {
                     "yarn.nodemanager.log-dirs" : "/var/log/pnda/hadoop-yarn/container",
+                    "yarn.nodemanager.local-dirs" : "/data0/yarn/nm",
+                    "yarn.nodemanager.localizer.cache.target-size-mb" : "1024",
                     "yarn.nodemanager.resource.cpu-vcores" : "8",
                     "yarn.nodemanager.resource.memory-mb" : "4096",
                     "yarn.log-aggregation.retain-seconds" : "7200",

--- a/salt/hdp/templates/cfg_production.py.tpl
+++ b/salt/hdp/templates/cfg_production.py.tpl
@@ -140,6 +140,7 @@ BLUEPRINT = r'''{
             "yarn-site" : {
                 "properties" : {
                     "yarn.nodemanager.log-dirs" : "/var/log/pnda/hadoop-yarn/container",
+                    "yarn.nodemanager.local-dirs" : "/data0/yarn/nm",
                     "yarn.nodemanager.resource.cpu-vcores" : "48",
                     "yarn.nodemanager.resource.memory-mb" : "78848",
                     "yarn.nodemanager.vmem-check-enabled": "false",

--- a/salt/hdp/templates/cfg_standard.py.tpl
+++ b/salt/hdp/templates/cfg_standard.py.tpl
@@ -139,6 +139,7 @@ BLUEPRINT = r'''{
             "yarn-site" : {
                 "properties" : {
                     "yarn.nodemanager.log-dirs" : "/var/log/pnda/hadoop-yarn/container",
+                    "yarn.nodemanager.local-dirs" : "/data0/yarn/nm",
                     "yarn.nodemanager.resource.cpu-vcores" : "7",
                     "yarn.nodemanager.resource.memory-mb" : "14336",
                     "yarn.log-aggregation.retain-seconds" : "265000",


### PR DESCRIPTION
To avoid using the operating system partition for data, use /data0 for
the yarn local dir.

PNDA-2486