### PR TITLE
Specify number of volumes to use for HDFS in pillar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-1788: Cloudera version can be set in the salt pillar
 - PNDA-3314: Added new flavor for larger PNDAs called "production"
 - PNDA-3484: Add CentOS support
+- PNDA-3497: Add pillar config to set how many data directories to configure HDFS to use.
 
 ### Changed
 - PNDA-2965: Rename `cloudera_*` role grains to `hadoop_*`

--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -14,10 +14,12 @@
             "kafka_heapsize": 2147483648
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_pico.py"
+            "template_file": "cfg_pico.py",
+            "data_volumes_count": 1
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_pico.py"
+            "template_file": "cfg_pico.py",
+            "data_volumes_count": 1
         },
         "curator": {
             "days_to_keep": 1

--- a/pillar/flavors/production.sls
+++ b/pillar/flavors/production.sls
@@ -10,10 +10,12 @@
             "max_mappers": 20
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_production.py"
+            "template_file": "cfg_production.py",
+            "data_volumes_count": 24
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_production.py"
+            "template_file": "cfg_production.py",
+            "data_volumes_count": 24
         },
         "curator": {
             "days_to_keep": 6

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -14,10 +14,12 @@
             "kafka_heapsize": 4294967296
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_standard.py"
+            "template_file": "cfg_standard.py",
+            "data_volumes_count": 1
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_standard.py"
+            "template_file": "cfg_standard.py",
+            "data_volumes_count": 1
         },
         "curator": {
             "days_to_keep": 6

--- a/salt/cdh/setup_hadoop.sls
+++ b/salt/cdh/setup_hadoop.sls
@@ -17,6 +17,17 @@
 {% set pnda_home = pillar['pnda']['homedir'] %}
 {% set app_packages_dir = pnda_home + "/apps-packages" %}
 
+{%- set data_volume_list = [] %}
+{%- for n in range(flavor_cfg.data_volumes_count) -%}
+  {%- if flavor_cfg.data_volumes_count > 10 and n < 10 -%}
+    {%- set prefix = '/data0' -%}
+  {%- else -%}
+    {%- set prefix = '/data' -%}
+  {%- endif -%}
+  {%- do data_volume_list.append(prefix ~ n ~ '/dn') %}
+{%- endfor -%}
+{%- set data_volumes = data_volume_list|join(",") %}
+
 include:
   - python-pip
 
@@ -62,6 +73,7 @@ cdh-copy_cm_config:
       aws_key: {{ aws_key }}
       aws_secret_key: {{ aws_secret_key }}
       app_packages_dir: {{ app_packages_dir }}
+      data_volumes: {{ data_volumes }}
 
 # Create a python configured scripts to call the cm_setup.setup_hadoop function with
 # the needed aguments (nodes to install cloudera to)

--- a/salt/cdh/templates/cfg_pico.py.tpl
+++ b/salt/cdh/templates/cfg_pico.py.tpl
@@ -282,7 +282,7 @@ HDFS_CFG = {
             },
             {
                 "type": "DATANODE",
-                "config": {'dfs_data_dir_list': '/data0/dn', 'datanode_log_dir': '/var/log/pnda/hadoop/dn',
+                "config": {'dfs_data_dir_list': '{{ data_volumes }}', 'datanode_log_dir': '/var/log/pnda/hadoop/dn',
                            'datanode_data_directories_free_space_absolute_thresholds': '{"warning":1073741824,"critical":1073741824}',
                            'heap_dump_directory_free_space_absolute_thresholds': '{"warning":"never","critical":5368709120}',
                            'log_directory_free_space_absolute_thresholds': '{"warning":4294967296,"critical":3221225472}',

--- a/salt/cdh/templates/cfg_production.py.tpl
+++ b/salt/cdh/templates/cfg_production.py.tpl
@@ -86,7 +86,7 @@ ZK_CFG = {"service": "ZOOKEEPER",
                                    'log_directory_free_space_absolute_thresholds': '{"warning": "1050000000","critical": "900000000"}',
                                    'zookeeper_server_java_heapsize': "4294967296"
                                    }}]}
-                                   
+
 
 
 
@@ -259,14 +259,14 @@ HDFS_CFG = {
             },
             {
                 "type": "DATANODE",
-                "config": {'dfs_data_dir_list': '/data0/dn', 
+                "config": {'dfs_data_dir_list': '{{ data_volumes }}',
                            'datanode_log_dir': '/var/log/pnda/hadoop/dn',
                            "datanode_java_heapsize": "2147483648"
                           }
             },
             {
                 "type": "JOURNALNODE",
-                "config": {'dfs_journalnode_edits_dir':'/data0/jn/data', 
+                "config": {'dfs_journalnode_edits_dir':'/data0/jn/data',
                            'journalnode_log_dir': '/var/log/pnda/hadoop/jn',
                            'journalNode_java_heapsize':"2147483648"}
             },
@@ -410,7 +410,7 @@ HIVE_CFG = {
             },
             {
                 "type": "HIVESERVER2",
-                "config": {'hive_log_dir': '/var/log/pnda/hive', 
+                "config": {'hive_log_dir': '/var/log/pnda/hive',
                            'hiveserver2_java_heapsize': '17179869184'
                           }
             },

--- a/salt/cdh/templates/cfg_standard.py.tpl
+++ b/salt/cdh/templates/cfg_standard.py.tpl
@@ -237,7 +237,7 @@ HDFS_CFG = {
             },
             {
                 "type": "DATANODE",
-                "config": {'dfs_data_dir_list': '/data0/dn', 'datanode_log_dir': '/var/log/pnda/hadoop/dn'}
+                "config": {'dfs_data_dir_list': '{{ data_volumes }}', 'datanode_log_dir': '/var/log/pnda/hadoop/dn'}
             },
             {
                 "type": "JOURNALNODE",

--- a/salt/hdp/setup_hadoop.sls
+++ b/salt/hdp/setup_hadoop.sls
@@ -15,6 +15,17 @@
 
 {% set pip_index_url = pillar['pip']['index_url'] %}
 
+{%- set data_volume_list = [] %}
+{%- for n in range(flavor_cfg.data_volumes_count) -%}
+  {%- if flavor_cfg.data_volumes_count > 10 and n < 10 -%}
+    {%- set prefix = '/data0' -%}
+  {%- else -%}
+    {%- set prefix = '/data' -%}
+  {%- endif -%}
+  {%- do data_volume_list.append(prefix ~ n ~ '/dn') %}
+{%- endfor -%}
+{%- set data_volumes = data_volume_list|join(",") %}
+
 include:
   - python-pip
 
@@ -60,6 +71,7 @@ hdp-copy_flavor_config:
       mysql_host: {{ mysql_host }}
       aws_key: {{ aws_key }}
       aws_secret_key: {{ aws_secret_key }}
+      data_volumes: {{ data_volumes }}
 
 hdp-execute_hdp_installation_script:
   cmd.run:

--- a/salt/hdp/templates/cfg_pico.py.tpl
+++ b/salt/hdp/templates/cfg_pico.py.tpl
@@ -276,7 +276,7 @@ BLUEPRINT = r'''{
                 "properties" : {
                     "dfs.replication" : "3",
                     "dfs.replication.max" : "50",
-                    "dfs.datanode.data.dir" : "/data0/dn"
+                    "dfs.datanode.data.dir" : "{{ data_volumes }}"
                 }
             }
         },

--- a/salt/hdp/templates/cfg_production.py.tpl
+++ b/salt/hdp/templates/cfg_production.py.tpl
@@ -310,7 +310,7 @@ BLUEPRINT = r'''{
                 "properties" : {
                     "dfs.replication" : "3",
                     "dfs.replication.max" : "50",
-                    "dfs.datanode.data.dir" : "/data0/dn",
+                    "dfs.datanode.data.dir" : "{{ data_volumes }}",
                     "dfs.client.failover.proxy.provider.HDFS-HA" : "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
                     "dfs.ha.automatic-failover.enabled" : "true",
                     "dfs.ha.fencing.methods" : "shell(/bin/true)",

--- a/salt/hdp/templates/cfg_standard.py.tpl
+++ b/salt/hdp/templates/cfg_standard.py.tpl
@@ -282,7 +282,7 @@ BLUEPRINT = r'''{
                 "properties" : {
                     "dfs.replication" : "3",
                     "dfs.replication.max" : "50",
-                    "dfs.datanode.data.dir" : "/data0/dn",
+                    "dfs.datanode.data.dir" : "{{ data_volumes }}",
                     "dfs.client.failover.proxy.provider.HDFS-HA" : "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
                     "dfs.ha.automatic-failover.enabled" : "true",
                     "dfs.ha.fencing.methods" : "shell(/bin/true)",


### PR DESCRIPTION
Add setting data_volumes_count in pillar/flavors/flavor.sls that can be
used to control how many data volumes are used by HDFS. The directory
names follow the pattern /data0/dn, /data1/dn ... /dataN/dn. N is
padded so the number of digits is always the same for all volumes e.g.
/data00 if there are more than 10 total volumes.

PNDA-3497