### PR TITLE
Place data directories on mnt in production flavor

### DIFF
--- a/pillar/flavors/bmstandard.sls
+++ b/pillar/flavors/bmstandard.sls
@@ -22,10 +22,18 @@
             "listen_iface": "vlan2006"
         },
         "zookeeper": {
-            "listen_iface": "vlan2006"
+            "listen_iface": "vlan2006",
+            "zookeeper_data_dir": "/var/lib/zookeeper"
         },
         "kafka.server": {
+            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824
+        },
+        "mysql": {
+            "data_dir": "/var/lib/mysql"
+        },
+        "elasticsearch": {
+            "datadir": "/var/lib/elasticsearch"
         }
     }
 }

--- a/pillar/flavors/distribution.sls
+++ b/pillar/flavors/distribution.sls
@@ -13,10 +13,18 @@
             "listen_iface": "vlan2506"
         },
         "zookeeper": {
-            "listen_iface": "vlan2506"
+            "listen_iface": "vlan2506",
+            "zookeeper_data_dir": "/var/lib/zookeeper"
         },
         "kafka.server": {
+            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824
+        },
+        "mysql": {
+            "data_dir": "/var/lib/mysql"
+        },
+        "elasticsearch": {
+            "datadir": "/var/lib/elasticsearch"
         }
     }
 }

--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -10,6 +10,7 @@
             "max_mappers": 5
         },
         "kafka.server": {
+            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 314572800,
             "kafka_heapsize": 2147483648
         },
@@ -25,10 +26,17 @@
             "days_to_keep": 1
         },
         "zookeeper": {
-            "zookeeper_heapsize": 1073741824
+            "zookeeper_heapsize": 1073741824,
+            "zookeeper_data_dir": "/var/lib/zookeeper"
         },
         "opentsdb": {
             "opentsdb_heapsize": 2147483648
+        },
+        "mysql": {
+            "data_dir": "/var/lib/mysql"
+        },
+        "elasticsearch": {
+            "datadir": "/var/lib/elasticsearch"
         }
     }
 }

--- a/pillar/flavors/production.sls
+++ b/pillar/flavors/production.sls
@@ -21,14 +21,22 @@
             "days_to_keep": 6
         },
         "kafka.server": {
+            "data_dirs": ["/mnt/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824,
             "kafka_heapsize": 17179869184
         },
         "zookeeper": {
-            "zookeeper_heapsize": 4294967296
+            "zookeeper_heapsize": 4294967296,
+            "zookeeper_data_dir": "/mnt/zookeeper"
         },
         "opentsdb": {
             "opentsdb_heapsize": 17179869184
+        },
+        "mysql": {
+            "data_dir": "/mnt/mysql"
+        },
+        "elasticsearch": {
+            "datadir": "/mnt/elasticsearch"
         }
     }
 }

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -10,6 +10,7 @@
             "max_mappers": 50
         },
         "kafka.server": {
+            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824,
             "kafka_heapsize": 4294967296
         },
@@ -25,10 +26,17 @@
             "days_to_keep": 6
         },
         "zookeeper": {
-            "zookeeper_heapsize": 2147483648
+            "zookeeper_heapsize": 2147483648,
+            "zookeeper_data_dir": "/var/lib/zookeeper"
         },
         "opentsdb": {
             "opentsdb_heapsize": 4294967296
+        },
+        "mysql": {
+            "data_dir": "/var/lib/mysql"
+        },
+        "elasticsearch": {
+            "datadir": "/var/lib/elasticsearch"
         }
     }
 }

--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -9,7 +9,6 @@ elasticsearch:
   version: 1.5.0
   directory: /opt/pnda
   logdir: /var/log/elasticsearch
-  datadir: /var/lib/elasticsearch
   confdir: /etc/elasticsearch
   workdir: /tmp/elasticsearch
 
@@ -37,9 +36,6 @@ kafka:
   internal_port: 9092
   replication_port: 9093
   ingest_port: 9094
-  config:
-    log_dirs:
-      - '/var/kafka-logs'
 
 kafkatool:
   release_version: v0.2.0

--- a/salt/cdh/templates/cfg_production.py.tpl
+++ b/salt/cdh/templates/cfg_production.py.tpl
@@ -37,15 +37,15 @@ CMS_CFG = {
           "config": {'mgmt_log_dir': '/var/log/pnda/cdh/cloudera-scm-alertpublisher',
                      "alert_heapsize": "1073741824"}},
          {"type": "EVENTSERVER",
-          "config": {'eventserver_index_dir': '/data0/var/lib/cloudera-scm-eventserver',
+          "config": {'eventserver_index_dir': '/mnt/var/lib/cloudera-scm-eventserver',
                      'mgmt_log_dir': '/var/log/pnda/cdh/cloudera-scm-eventserver',
                      "event_server_heapsize": "2147483648"}},
          {"type": "HOSTMONITOR",
-          "config": {'firehose_storage_dir': '/data0/var/lib/cloudera-host-monitor',
+          "config": {'firehose_storage_dir': '/mnt/var/lib/cloudera-host-monitor',
                      'mgmt_log_dir': '/var/log/pnda/cdh/cloudera-scm-firehose',
                      "firehose_heapsize":"2147483648"}},
          {"type": "SERVICEMONITOR",
-          "config": {'firehose_storage_dir': '/data0/var/lib/cloudera-service-monitor',
+          "config": {'firehose_storage_dir': '/mnt/var/lib/cloudera-service-monitor',
                      'mgmt_log_dir': '/var/log/pnda/cdh/cloudera-scm-firehose',
                      "firehose_heapsize": "2147483648"}}]
 }
@@ -58,7 +58,7 @@ OOZIE_CFG = {"service": "OOZIE",
                         "type": "OOZIE_SERVER",
                         "target": "MGR04"}],
              "role_cfg": [{"type": "OOZIE_SERVER",
-                           "config": {'oozie_data_dir': '/data0/var/lib/oozie/data',
+                           "config": {'oozie_data_dir': '/mnt/var/lib/oozie/data',
                                       'oozie_log_dir': '/var/log/pnda/oozie',
                                       'oozie_database_type': 'mysql',
                                       'oozie_database_host': '{{ mysql_host }}',
@@ -80,8 +80,8 @@ ZK_CFG = {"service": "ZOOKEEPER",
                      "type": "SERVER",
                      "target": "MGR04"}],
           "role_cfg": [{"type": "SERVER",
-                        "config": {'dataDir': '/data0/var/lib/zookeeper',
-                                   'dataLogDir': '/data0/var/lib/zookeeper',
+                        "config": {'dataDir': '/mnt/var/lib/zookeeper',
+                                   'dataLogDir': '/mnt/var/lib/zookeeper',
                                    'zk_server_log_dir': '/var/log/pnda/zookeeper',
                                    'log_directory_free_space_absolute_thresholds': '{"warning": "1050000000","critical": "900000000"}',
                                    'zookeeper_server_java_heapsize': "4294967296"
@@ -140,7 +140,7 @@ MAPRED_CFG = {
             "config":
                 {
                     'yarn_nodemanager_heartbeat_interval_ms': 100,
-                    'yarn_nodemanager_local_dirs': '/data0/yarn/nm',
+                    'yarn_nodemanager_local_dirs': '/mnt/yarn/nm',
                     'yarn_nodemanager_log_dirs': '/var/log/pnda/hadoop-yarn/container',
                     'node_manager_log_dir': '/var/log/pnda/hadoop-yarn',
                     'yarn_nodemanager_resource_cpu_vcores': '48',
@@ -193,7 +193,7 @@ HDFS_CFG = {
         {
             'dfs_replication': 2,
             'core_site_safety_valve':
-                ('<property> <name>hadoop.tmp.dir</name><value>/data0/tmp/hadoop-${user.name}</value></property>\r\n\r\n'
+                ('<property> <name>hadoop.tmp.dir</name><value>/mnt/tmp/hadoop-${user.name}</value></property>\r\n\r\n'
                  '<property> \r\n<name>hadoop.proxyuser.yarn.hosts</name>\r\n<value>*</value>\r\n</property>\r\n\r\n'
                  '<property>\r\n<name>hadoop.proxyuser.yarn.groups</name>\r\n<value>*</value>\r\n</property>') + SWIFT_CONFIG + S3_CONFIG,
             'dfs_block_local_path_access_user': 'impala'
@@ -250,7 +250,7 @@ HDFS_CFG = {
         [
             {
                 "type": "NAMENODE",
-                "config": {'dfs_name_dir_list': '/data0/nn',
+                "config": {'dfs_name_dir_list': '/mnt/nn',
                            'dfs_namenode_handler_count': 60,
                            'dfs_namenode_service_handler_count': 60,
                            'namenode_log_dir': '/var/log/pnda/hadoop/nn',
@@ -266,13 +266,13 @@ HDFS_CFG = {
             },
             {
                 "type": "JOURNALNODE",
-                "config": {'dfs_journalnode_edits_dir':'/data0/jn/data',
+                "config": {'dfs_journalnode_edits_dir':'/mnt/jn/data',
                            'journalnode_log_dir': '/var/log/pnda/hadoop/jn',
                            'journalNode_java_heapsize':"2147483648"}
             },
             {
                 "type": "SECONDARYNAMENODE",
-                "config": {'fs_checkpoint_dir_list': '/data0/snn',
+                "config": {'fs_checkpoint_dir_list': '/mnt/snn',
                            'secondarynamenode_log_dir': '/var/log/pnda/hadoop/snn',
                            'secondary_namenode_java_heapsize': 17179869184}
             },

--- a/salt/elasticsearch/init.sls
+++ b/salt/elasticsearch/init.sls
@@ -1,3 +1,5 @@
+{% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
+
 {% set es_p = pillar['elasticsearch'] %}
 {% do es_p.update({'directory': es_p.directory + '/elasticsearch-' + es_p.version}) %}
 
@@ -19,7 +21,7 @@ elasticsearch-elasticsearch:
 
 elasticsearch-create_elasticsearch_datadir:
   file.directory:
-    - name: {{ es_p.datadir }}
+    - name: {{ flavor_cfg.datadir }}
     - user: elasticsearch
     - group: elasticsearch
     - dir_mode: 755
@@ -82,7 +84,7 @@ elasticsearch-dl_and_extract_elasticsearch:
     - context:
       installdir: {{ es_p.directory }}
       logdir: {{ es_p.logdir }}
-      datadir: {{ es_p.datadir }}
+      datadir: {{ flavor_cfg.datadir }}
       confdir: {{ es_p.confdir }}
       workdir: {{ es_p.workdir }}
       defaultconfig: {{ es_p.confdir }}/elasticsearch.yml

--- a/salt/hdp/templates/cfg_production.py.tpl
+++ b/salt/hdp/templates/cfg_production.py.tpl
@@ -140,7 +140,7 @@ BLUEPRINT = r'''{
             "yarn-site" : {
                 "properties" : {
                     "yarn.nodemanager.log-dirs" : "/var/log/pnda/hadoop-yarn/container",
-                    "yarn.nodemanager.local-dirs" : "/data0/yarn/nm",
+                    "yarn.nodemanager.local-dirs" : "/mnt/hadoop/yarn/nm",
                     "yarn.nodemanager.resource.cpu-vcores" : "48",
                     "yarn.nodemanager.resource.memory-mb" : "78848",
                     "yarn.nodemanager.vmem-check-enabled": "false",
@@ -169,7 +169,8 @@ BLUEPRINT = r'''{
                     "yarn.resourcemanager.webapp.https.address" : "%(cluster_name)s-hadoop-mgr-1:8090",
                     "yarn.timeline-service.address" : "%(cluster_name)s-hadoop-mgr-3:10200",
                     "yarn.timeline-service.webapp.address" : "%(cluster_name)s-hadoop-mgr-3:8188",
-                    "yarn.timeline-service.webapp.https.address" : "%(cluster_name)s-hadoop-mgr-3:8190"
+                    "yarn.timeline-service.webapp.https.address" : "%(cluster_name)s-hadoop-mgr-3:8190",
+                    "yarn.timeline-service.leveldb-timeline-store.path" : "/mnt/hadoop/yarn/timeline"
                 }
             }
         },
@@ -205,7 +206,7 @@ BLUEPRINT = r'''{
         {
             "zoo.cfg" : {
                 "properties" : {
-                    "dataDir" : "/data0/zookeeper"
+                    "dataDir" : "/mnt/hadoop/zookeeper"
                 }
             }
         },
@@ -213,7 +214,7 @@ BLUEPRINT = r'''{
             "oozie-env" : {
                     "properties" : {
                     "oozie_log_dir" : "/var/log/pnda/oozie",
-                    "oozie_data_dir" : "/data0/var/lib/oozie/data",
+                    "oozie_data_dir" : "/mnt/hadoop/oozie/data",
                     "oozie_user" : "oozie",
                     "oozie_admin_users" : "{oozie_user}, oozie-admin",
                     "oozie_database" : "Existing MySQL / MariaDB Database",
@@ -279,6 +280,7 @@ BLUEPRINT = r'''{
             "hbase-site" : {
                 "properties" : {
                     "zookeeper.session.timeout" : "300000",
+                    "hbase.tmp.dir" : "/mnt/hadoop/hbase/tmp",
                     "hbase.rootdir" : "hdfs://HDFS-HA:8020/apps/hbase/data"
                 }
             }
@@ -315,6 +317,7 @@ BLUEPRINT = r'''{
                     "dfs.ha.automatic-failover.enabled" : "true",
                     "dfs.ha.fencing.methods" : "shell(/bin/true)",
                     "dfs.ha.namenodes.HDFS-HA" : "nn1,nn2",
+                    "dfs.journalnode.edits.dir" : "/mnt/hadoop/hdfs/jn",
                     "dfs.namenode.http-address" : "%(cluster_name)s-hadoop-mgr-1:50070",
                     "dfs.namenode.http-address.HDFS-HA.nn1" : "%(cluster_name)s-hadoop-mgr-1:50070",
                     "dfs.namenode.http-address.HDFS-HA.nn2" : "%(cluster_name)s-hadoop-mgr-2:50070",
@@ -324,7 +327,9 @@ BLUEPRINT = r'''{
                     "dfs.namenode.rpc-address.HDFS-HA.nn1" : "%(cluster_name)s-hadoop-mgr-1:8020",
                     "dfs.namenode.rpc-address.HDFS-HA.nn2" : "%(cluster_name)s-hadoop-mgr-2:8020",
                     "dfs.namenode.shared.edits.dir" : "qjournal://%(cluster_name)s-hadoop-mgr-1:8485;%(cluster_name)s-hadoop-mgr-2:8485;%(cluster_name)s-hadoop-mgr-4:8485/HDFS-HA",
-                    "dfs.nameservices" : "HDFS-HA"
+                    "dfs.nameservices" : "HDFS-HA",
+                    "dfs.namenode.checkpoint.dir" : "/mnt/hadoop/hdfs/snn",
+                    "dfs.namenode.name.dir" : "/mnt/hadoop/hdfs/nn"
                 }
             }
         },
@@ -357,6 +362,7 @@ BLUEPRINT = r'''{
                     "hadoop.security.auth_to_local" : "DEFAULT",
                     "hadoop.security.authentication" : "simple",
                     "hadoop.security.authorization" : "false",
+                    "hadoop.tmp.dir" : "/mnt/hadoop-tmp/${user.name}",
                     "io.compression.codecs" : "org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.SnappyCodec",
                     "io.file.buffer.size" : "131072",
                     "io.serializations" : "org.apache.hadoop.io.serializer.WritableSerialization",

--- a/salt/kafka-tool/init.sls
+++ b/salt/kafka-tool/init.sls
@@ -1,4 +1,5 @@
 #read all pillar data
+{% set flavor_cfg = pillar['pnda_flavor']['states']['kafka.server'] %}
 
 {% set install_dir = pillar['pnda']['homedir'] %}
 {% set packages_server = pillar['packages_server']['base_uri'] %}
@@ -8,7 +9,7 @@
 
 {% set p  = salt['pillar.get']('kafka', {}) %}
 {% set local_kafka_path = p.get('prefix', '/opt/pnda/kafka') %}
-{% set kafka_log_path = pillar['kafka']['config']['log_dirs'][0] %}
+{% set kafka_log_path = flavor_cfg.data_dirs[0] %}
 
 {%- set zk_ips = [] -%}
 {%- for ip in salt['pnda.kafka_zookeepers_ips']() -%}
@@ -33,7 +34,7 @@ kafka-tool-create_link:
 kafka-tool-install_packages:
   pkg.installed:
     - pkgs:
-      - {{ pillar['ruby-devel']['package-name'] }} 
+      - {{ pillar['ruby-devel']['package-name'] }}
       - {{ pillar['g++']['package-name'] }}
       - {{ pillar['patch']['package-name'] }}
 

--- a/salt/kafka/settings.sls
+++ b/salt/kafka/settings.sls
@@ -2,6 +2,7 @@
 {% set pc = p.get('config', {}) %}
 {% set g  = salt['grains.get']('kafka', {}) %}
 {% set gc = g.get('config', {}) %}
+{% set flavor_cfg = pillar['pnda_flavor']['states']['kafka.server'] %}
 
 # these are global - hence pillar-only
 {%- set prefix            = p.get('prefix', '/opt/pnda/kafka') %}
@@ -21,7 +22,7 @@
   'broker_id': gc.get('broker_id', pc.get('broker_id', 0)),
   'port': gc.get('port', pc.get('port', 9092)),
   'zookeeper_connect': gc.get('zookeeper_connect', pc.get('zookeeper_connect', 'localhost:2181')),
-  'log_dirs': gc.get('log_dirs', pc.get('log_dirs', ['/tmp/kafka-logs'])),
+  'log_dirs': flavor_cfg.data_dirs,
   'num_partitions': gc.get('num_partitions', pc.get('num_partitions', 2)),
   'log_retention_bytes': gc.get('log_retention_bytes', pc.get('log_retention_bytes', 16106127360)),
   'host_name': gc.get('host_name', pc.host_name),

--- a/salt/zookeeper/init.sls
+++ b/salt/zookeeper/init.sls
@@ -10,7 +10,6 @@
 {% set zookeeper_url = mirror_location + zookeeper_package %}
 
 {% set install_dir = pillar['pnda']['homedir'] %}
-{% set zookeeper_data_dir = '/var/lib/zookeeper' %}
 
 zookeeper-user-group:
   group.present:
@@ -23,7 +22,7 @@ zookeeper-user-group:
 
 zookeeper-data-dir:
   file.directory:
-    - name: {{ zookeeper_data_dir }}
+    - name: {{ flavor_cfg.zookeeper_data_dir }}
     - user: zookeeper
     - group: zookeeper
     - mode: 755
@@ -49,7 +48,7 @@ zookeeper-dl-and-extract:
 
 zookeeper-myid:
   file.managed:
-    - name: {{ zookeeper_data_dir }}/myid
+    - name: {{ flavor_cfg.zookeeper_data_dir }}/myid
     - source: salt://zookeeper/files/templates/zookeeper-myid.tpl
     - template: jinja
     - context:
@@ -77,7 +76,7 @@ zookeeper-configuration:
           ip: {{ node.ip }}
           fqdn: {{ node.fqdn }}
       {%- endfor %}
-      data_dir: {{ zookeeper_data_dir }}
+      data_dir: {{ flavor_cfg.zookeeper_data_dir }}
     - mode: 644
 
 zookeeper-environment:


### PR DESCRIPTION
Place data directories for all the main elements on mnt in production flavor:
 - hadoop
 - mysql
 - zookeeper
 - kafka
 - elasticsearch

PNDA-3489