### PR TITLE
PNDA-3345: Provide the app_packages HDFS location (from Pillar) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - PNDA-3484: Add CentOS support
 - PNDA-3497: Add pillar config to set how many data directories to configure HDFS to use.
 - PNDA-3478: Added support for Spark2 on HDP
+- PNDA-3345: Provide the app_packages HDFS location (from Pillar) to applications deployed with DM
+
 
 ### Changed
 - PNDA-2965: Rename `cloudera_*` role grains to `hadoop_*`

--- a/salt/deployment-manager/templates/dm-config.json.tpl
+++ b/salt/deployment-manager/templates/dm-config.json.tpl
@@ -51,6 +51,7 @@
 {% set repository_manager_link = salt['pnda.generate_http_link']('package_repository',':8888') %}
 
 {%- set keys_directory = pillar['deployment_manager']['keys_directory'] -%}
+{% set app_packages_hdfs_path = pillar['pnda']['app_packages']['app_packages_hdfs_path'] -%}
 
 
 {
@@ -70,6 +71,7 @@
         "metric_logger_url": "{{ data_logger_link }}/metrics",
         "jupyter_host": "{{ jupyter_host }}",
         "jupyter_notebook_directory": "jupyter_notebooks",
+        "app_packages_hdfs_path":"{{ app_packages_hdfs_path }}",
         "application_default_user": "{{ application_default_user }}"
     },
     "config": {


### PR DESCRIPTION
# **User Story:**
PNDA-3345: Provide the app_packages HDFS location (from Pillar) to applications deployed with DM 
Make packages deployed via app-packages available to applications via injecting parameter

An application can use app_packges location defined in pillar " pillar['pnda']['app_packages']['app_packages_hdfs_path']"  to load libraries that are deployed in this location otherwise, user need to hard-code paths or use some other out-of-band mechanism to know where things are.

# **Changes:**
**deployment-manager/dm-config.json**
   Export the pillar app-packages path to Deployment manager as Environment variable.