### PR TITLE
Added missing parameters in yarn-site section

### DIFF
--- a/salt/hdp/templates/cfg_standard.py.tpl
+++ b/salt/hdp/templates/cfg_standard.py.tpl
@@ -178,7 +178,11 @@ BLUEPRINT = r'''{
                     "yarn.resourcemanager.scheduler.address" : "%(cluster_name)s-hadoop-mgr-1:8030",
                     "yarn.resourcemanager.store.class" : "org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore",
                     "yarn.resourcemanager.webapp.address" : "%(cluster_name)s-hadoop-mgr-1:8088",
+                    "yarn.resourcemanager.webapp.address.rm1" : "%(cluster_name)s-hadoop-mgr-1:8088",
+		    "yarn.resourcemanager.webapp.address.rm2" : "%(cluster_name)s-hadoop-mgr-2:8088",
                     "yarn.resourcemanager.webapp.https.address" : "%(cluster_name)s-hadoop-mgr-1:8090",
+		    "yarn.resourcemanager.webapp.https.address.rm1" : "%(cluster_name)s-hadoop-mgr-1:8090",
+		    "yarn.resourcemanager.webapp.https.address.rm2" : "%(cluster_name)s-hadoop-mgr-2:8090",
                     "yarn.timeline-service.address" : "%(cluster_name)s-hadoop-mgr-3:10200",
                     "yarn.timeline-service.webapp.address" : "%(cluster_name)s-hadoop-mgr-3:8188",
                     "yarn.timeline-service.webapp.https.address" : "%(cluster_name)s-hadoop-mgr-3:8190"


### PR DESCRIPTION
FIX for Issue- #385 

"yarn.resourcemanager.webapp.address.rm1" : "%(cluster_name)s-hadoop-mgr-1:8088",
"yarn.resourcemanager.webapp.address.rm2" : "%(cluster_name)s-hadoop-mgr-2:8088",
"yarn.resourcemanager.webapp.https.address.rm1" : "%(cluster_name)s-hadoop-mgr-1:8090",
"yarn.resourcemanager.webapp.https.address.rm2" : "%(cluster_name)s-hadoop-mgr-2:8090",

Added above parameters in yarn-site section inside hdp/templates/cfg_standard.py.tpl to run hadoop mapreduce jobs without any issues in HDP Cluster.