### PR TITLE
Changed ownership of gobblin log directory

### DIFF
--- a/salt/gobblin/init.sls
+++ b/salt/gobblin/init.sls
@@ -83,6 +83,7 @@ gobblin-install_gobblin_pnda_job_file:
 gobblin-create_gobblin_logs_directory:
   file.directory:
     - name: /var/log/pnda/gobblin
+    - user: {{ pnda_user }}
     - makedirs: True
 
 gobblin-install_gobblin_service_script:


### PR DESCRIPTION
Fix for Issue- #390 

gobblin-create_gobblin_logs_directory:
file.directory:
- name: /var/log/pnda/gobblin
- makedirs: True
**- user: pnda**

Added additional parameter "user: pnda" inside gobblin/init.sls so that it generates gobblin logs without any permission issue.(Gobblin service script is owned by user pnda)