### PR TITLE
PNDA-3133: Remove Gobblin fork and use release distribution instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3600: Make the spark/MR cli wrapper the master system cli.
 - PNDA-3581: Create a mapping table for the Fair Scheduler queue setup (CDH) of PNDA-3527.
 - PNDA-3529: Make Jupyter use the system spark cli.
+- PNDA-3133: Remove Gobblin fork and use apache release distribution / Fixed issue to run the mapreduce job appropriately.
 
 ### Fixed
 - PNDA-3573: remove eth0 default value on kafka

--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -55,7 +55,7 @@ jupyterproxy:
   release_version: 1.3.1
 
 gobblin:
-  release_version: develop
+  release_version: 0.11.0
 
 console_frontend:
   release_version: develop

--- a/salt/gobblin/init.sls
+++ b/salt/gobblin/init.sls
@@ -61,6 +61,14 @@ gobblin-update_gobblin_reference_configuration_file:
     - require:
       - archive: gobblin-dl-and-extract
 
+gobblin-update_gobblin_mapreduce_sh_file:
+  file.replace:
+    - name: {{ gobblin_real_dir }}/gobblin-dist/bin/gobblin-mapreduce.sh
+    - pattern: 'data-2.6.0.jar'
+    - repl: 'data-11.0.0.jar'
+    - require:
+      - archive: gobblin-dl-and-extract
+
 gobblin-create_gobblin_jobs_directory:
   file.directory:
     - name: {{ gobblin_link_dir }}/configs
@@ -85,6 +93,13 @@ gobblin-create_gobblin_logs_directory:
     - name: /var/log/pnda/gobblin
     - user: {{ pnda_user }}
     - makedirs: True
+
+gobblin-create_gobblin_logs_file:
+  file.managed:
+    - name: /var/log/pnda/gobblin/gobblin-current.log
+    - user: pnda
+    - group: pnda
+    - mode: 0644
 
 gobblin-install_gobblin_service_script:
   file.managed:


### PR DESCRIPTION
# Problem Statement:
PNDA-3133: Remove Gobblin fork and use release distribution instead.
Fix for Issue- #390

# Analysis:
- currently, as not a upstream project the release version for gobblin is develop.
- The gobblin job is not executing successfuly because gobblin-current.log file is not created/available to write the logs. 
- the data-x.x.x.jar - the actual file version ( 11.0.0 ) and gobblin-mapreduce.sh reference( from older release - 2.6.0 ) are mismatching.  

# Change:
- Changed the release version to latest one i.e. 0.11.0
- Created the log file for gobblin job execution.
-  updated the data-x.x.x.jar file version appropriately.

# Test details:
Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
Verification pending for OpenStack.