### PR TITLE
PNDA-1322: Test Master Dataset Health

### DIFF
--- a/salt/volumes/init.sls
+++ b/salt/volumes/init.sls
@@ -61,7 +61,16 @@
     {% else %}
     volumes-wait-{{ device }}:
       cmd.run:
-        - name: 'while [ ! -b {{ device }} ]; do   echo waiting for device {{ device }}; sleep 2; done'
+        - name: |
+            DISK_READY_RETRIES=0
+            DISK_READY_RETRY_LIMIT=60
+            DISK_READY_RETRY_INTERVAL=2
+            DEVICE={{ device }}
+            until [ -b $DEVICE ] || [ $DISK_READY_RETRIES -eq $DISK_READY_RETRY_LIMIT ]; do
+                sleep $DISK_READY_RETRY_INTERVAL
+                echo waiting for device $DEVICE - retry $(( DISK_READY_RETRIES++ )) of $DISK_READY_RETRY_LIMIT
+            done
+            [ ! $DISK_READY_RETRIES -eq $DISK_READY_RETRY_LIMIT ]
 
     volumes-format-{{ device }}:
       cmd.run:


### PR DESCRIPTION
# Problem Statement:
PNDA-1322: Test Master Dataset Health

# Analysis:
1.  Run Gobblin service manually(Before CRON Job run) to test Gobblin health initially
2.  Add CRON tab entry for Gobblin after initial Gobblin run
3.  Remove KAFKA internal test topic from blacklist in Gobblin configuration file
4.  Create service file and add CRON tab entry to run plugin(dataset) in platform-testing to test Master 
     Dataset Health

# Approach:
1. Add state file inside Gobblin directory to run Gobblin service manually
2. Add CRON tab entry for Gobblin after executing Gobblin service initially to avoid simultaneous runs
3. In order to test Dataset creation remove KAFKA internal test topic from Gobblin's blacklist
4. Add additional steps in platform-testing state to create service file and schedule CRON job to run 
    dataset plugin(To test Master Dataset Health)

# Test details:
UBUNTU-PICO-CDH
UBUNTU-STD-CDH
UBUNTU-PICO-HDP
UBUNTU-STD-HDP
RHEL-PICO-CDH
RHEL-STD-CDH
RHEL-PICO-HDP
RHEL-STD-HDP