### PR TITLE
Add the title to the Spark magic minimal/example notebook & correct the kernel for sqlmagic notebook.

### DIFF
--- a/salt/jupyter/files/notebooks/PNDA minimal Spark notebook.ipynb
+++ b/salt/jupyter/files/notebooks/PNDA minimal Spark notebook.ipynb
@@ -1,5 +1,12 @@
 {
  "cells": [
+   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Minimal PNDA SparkMagic notebook"
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": null,

--- a/salt/jupyter/files/notebooks/PNDA minimal SqlMagic notebook.ipynb
+++ b/salt/jupyter/files/notebooks/PNDA minimal SqlMagic notebook.ipynb
@@ -10,7 +10,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "'''\n",
@@ -35,9 +37,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 2 (Anaconda)",
    "language": "python",
-   "name": "python2"
+   "name": "anacondapython2"
   },
   "language_info": {
    "codemirror_mode": {
@@ -49,9 +51,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Fix for Issue- #396
Case - Use consistent format for the example minimal jupyter notebooks
Issue - The Spark minimal notebook doesn't have the title added.
Issue - SQL magic jupyter notebook referring to the in-correct kernel ( missed check-in )
Fix 
- Use consistent format for the example minimal jupyter notebooks
- Correct the sql magic notebook kernel.