### PR TITLE
Make the spark cli wrapper the master spark cli of the system.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3583: hadoop distro is now part of grains
 - PNDA-2540: Stop supplying 'cloud-user' as the default operating system user as this is deployment specific and must be supplied in the pnda-env.yaml
 - PNDA-1899: Scala Spark Jupyter Integration
+- PNDA-3600: Make the spark cli wrapper the master spark cli of the system.
 
 ### Fixed
 - PNDA-3573: remove eth0 default value on kafka

--- a/salt/resource-manager/files/spark-no-policy.sh
+++ b/salt/resource-manager/files/spark-no-policy.sh
@@ -1,0 +1,2 @@
+echo $1
+exit 0

--- a/salt/resource-manager/init.sls
+++ b/salt/resource-manager/init.sls
@@ -1,7 +1,7 @@
 {% set resource_manager_dir = pillar['pnda']['homedir'] + "/spark-wrapper" %}
 {% set map_file = resource_manager_dir + "/policies/map.txt" %}
 
-resource-manager_group_script_install:
+resource-manager_user-group-policy_install:
   file.managed:
     - name: {{ resource_manager_dir }}/policies/spark-user-group-policy.sh
     - source: salt://resource-manager/templates/spark-user-group-policy.sh
@@ -11,6 +11,12 @@ resource-manager_group_script_install:
     - mode: 755
     - makedirs: True
     - dir_mode: 755
+
+resource-manager_no_policy_install:
+  file.managed:
+    - name: {{ resource_manager_dir }}/policies/spark-no-policy.sh
+    - source: salt://resource-manager/files/spark-no-policy.sh
+    - mode: 755
 
 resource-manager_group_map_install:
   file.managed:
@@ -44,3 +50,91 @@ resource-manager_spark_shell:
     - name: {{ resource_manager_dir }}/spark-shell
     - target: {{ resource_manager_dir }}/spark-common-wrapper.sh
     - mode: 755
+
+resource-manager_pyspark:
+  file.symlink:
+    - name: {{ resource_manager_dir }}/pyspark
+    - target: {{ resource_manager_dir }}/spark-common-wrapper.sh
+    - mode: 755
+
+resource-manager_spark_submit_move:
+  file.rename:
+    - name: /opt/pnda/spark/spark-submit
+    - source: /usr/bin/spark-submit
+    - makedirs: True
+    - unless: 
+      - test -L /usr/bin/spark-submit
+
+resource-manager_spark_shell_move:
+  file.rename:
+    - name: /opt/pnda/spark/spark-shell
+    - source: /usr/bin/spark-shell
+    - makedirs: True
+    - unless: 
+      - test -L /usr/bin/spark-shell
+
+resource-manager_pyspark_move:
+  file.rename:
+    - name: /opt/pnda/spark/pyspark
+    - source: /usr/bin/pyspark
+    - makedirs: True
+    - unless: 
+      - test -L /usr/bin/pyspark
+
+resource-manager_spark_script_move:
+  file.rename:
+    - name: /opt/pnda/spark/spark-script-wrapper.sh
+    - source: /usr/bin/spark-script-wrapper.sh
+    - makedirs: True
+    - onlyif: 
+      - test -x /usr/bin/spark-script-wrapper.sh
+
+resource-manager_spark_submit_orig:
+  alternatives.install:
+    - name: spark-submit
+    - link: /usr/bin/spark-submit
+    - path: /opt/pnda/spark/spark-submit
+    - priority: 10
+    - onlyif:
+      - test -x /opt/pnda/spark/spark-submit
+
+resource-manager_spark_shell_orig:
+  alternatives.install:
+    - name: spark-shell
+    - link: /usr/bin/spark-shell
+    - path: /opt/pnda/spark/spark-shell
+    - priority: 10
+    - onlyif:
+      - test -x /opt/pnda/spark/spark-shell
+
+resource-manager_pyspark_orig:
+  alternatives.install:
+    - name: pyspark
+    - link: /usr/bin/pyspark
+    - path: /opt/pnda/spark/pyspark
+    - priority: 10
+    - onlyif:
+      - test -x /opt/pnda/spark/pyspark
+
+resource-manager_spark_submit_wrapper:
+  alternatives.install:
+    - name: spark-submit
+    - link: /usr/bin/spark-submit
+    - path: {{ resource_manager_dir }}/spark-submit
+    - priority: 100
+
+resource-manager_spark_shell_wrapper:
+  alternatives.install:
+    - name: spark-shell
+    - link: /usr/bin/spark-shell
+    - path: {{ resource_manager_dir }}/spark-shell
+    - priority: 100
+
+resource-manager_pyspark_wrapper:
+  alternatives.install:
+    - name: pyspark
+    - link: /usr/bin/pyspark
+    - path: {{ resource_manager_dir }}/pyspark
+    - priority: 100
+
+

--- a/salt/resource-manager/templates/map.txt
+++ b/salt/resource-manager/templates/map.txt
@@ -1,7 +1,20 @@
-# Mapping table of the form
-# user:group queue
-# when the user is empty, the whole group will be mmaped to the queue
-# when the group is empty, he user will be ammped to the queue irrespective of the group
-pnda:pnda system
+# Mapping table. 
+# --------------
+#
+# Supported Rule Syntax
+# user: queue 
+# :group queue
+#
+# when the group is empty (first rule above), the user will be mapped to the queue irrespective of the group
+# when the user is empty (second rule above), the whole group will be mapped to the queue
+# when both the user and the group are defined, the group will be ignored
+
+# The 'pnda' user will be mapped to the default queue.
+pnda: default
+
+# The 'prod' group users will be mapped to the prod queue unless the dev queue is explicitly requested.
 :prod prod
-dev1 dev
+:prod dev
+
+# The 'dev' group users will be mapped to the dev queue. 
+:dev dev

--- a/salt/resource-manager/templates/spark-common-wrapper.sh
+++ b/salt/resource-manager/templates/spark-common-wrapper.sh
@@ -2,20 +2,51 @@
 
 # Find which script to call
 CALLER_DIR="$(cd "`dirname "$0"`"; pwd)"
-if [ "$CALLER_DIR" == "/usr/bin" ]; then
-  # Avoid loops.
+if [ "$CALLER_DIR" == "/usr/bin" ] || [ "$CALLER_DIR" == "/bin" ] || [ "$CALLER_DIR" == "{{ resource_manager_dir }}" ]; then
+  # The wrapper (or master alternative) is the caller, so we can now call the original script.
   script=`basename "$0"`
-  EXECUTABLE="$(update-alternatives --list "$script" | fgrep -v '/usr/bin' | head -n 1)"
+  EXECUTABLE="$(update-alternatives --display "$script" | egrep -v '^/bin' | egrep -v '^/usr/bin' | egrep -o ^/.*"${script}" | head -n 1)"
   if [ "X$EXECUTABLE" == "X" ]; then
     echo "There is no alternative for $script"
-    exit
+    exit 1
   fi
 else
   EXECUTABLE="/usr/bin/$(basename "$0")"
 fi
 
 # Set the queue in the argument list
-. {{ resource_manager_dir }}/spark-policy.sh
+
+REQUEST=''
+KEEP=()
+# Find the requested queue
+# and keep all other the options
+while [[ $# -gt 0 ]]
+do
+  case "${1}" in
+  --queue)
+      REQUEST="${2}"
+      shift 2
+      ;;
+  *)
+      KEEP+=("${1}")
+      shift
+      ;;
+  esac
+done
+
+# define the appropriate queue according to the policy
+QUEUE=`{{ resource_manager_dir }}/spark-policy.sh ${REQUEST}`
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then 
+  echo "Error: spark-policy returned exit $EXIT_CODE: $QUEUE"
+  exit 2
+fi
+
+# assemble the arguments and call the function
+if [ "X$QUEUE" != "X" ]; then
+  KEEP=("--queue" "$QUEUE" "${KEEP[@]}")
+fi 
+set -- "${KEEP[@]}"
 
 # Call the script with all the arguments.
 echo "Executing: $EXECUTABLE $@"

--- a/salt/resource-manager/templates/spark-user-group-policy.sh
+++ b/salt/resource-manager/templates/spark-user-group-policy.sh
@@ -1,55 +1,53 @@
 #!/usr/bin/env bash
 # This code implements a user/group based queue placement policy.
 
-MAP={{ map_file }}
-REQUEST=''
-
-KEEP=()
-# Find the requested queue
-# and keep all other the options
-while [[ $# -gt 0 ]]
-do
-  case "${1}" in
-  --queue)
-      REQUEST="${2}"
-      shift 2
-      ;;
-  *)
-      KEEP+=("${1}")
-      shift
-      ;;
-  esac
-done
-
+define_queue ()
+{
 # See who is submitting the request
-USER_NAME=`id -un`
-USER_GROUPS=`id -Gn`
+local REQUEST=$1
+local USER_NAME=`id -un`
+local USER_GROUPS=`id -Gn`
 
+local MAP={{ map_file }}
 if [ ! -f $MAP ]; then
   echo "$MAP file missing"
-  exit 2
+  exit 1
 fi
 
-TARGET=''
+QUEUE=''
 # Read in the map tables
 while read member queue; do
   [[ "$member" =~ ^#.* ]] && continue
   user=`echo "$member" | awk -F':' '{print $1}'`
   group=`echo "$member" | awk -F':' '{print $2}'`
   if [ "X$user" == "X$USER_NAME" ]; then
-    TARGET="$queue"
-  elif [ "X$group" != "X" ]; then
+    QUEUE="$queue"
+  elif [ "X$user" == "X" ] && [ "X$group" != "X" ]; then
     if echo "$USER_GROUPS" | grep -q -w "$group" ; then
-      TARGET="$queue"
+      QUEUE="$queue"
     fi
   fi
-  if [ "X$TARGET" != "X" ] && [ "X$REQUEST" == "X$TARGET" ]; then
-    # if this is the requested queue, then we are done
-    break;
+  if [ "X$QUEUE" != "X" ]; then 
+    if [ "X$REQUEST" == "X$QUEUE" ] || [ "X$REQUEST" == "X" ] ; then
+      # if this is the requested queue or no queue was requested, then we are done
+      break;
+    else 
+      QUEUE=''
+    fi
   fi
 done < $MAP
+}
 
-# Overwrite any queue setting
-KEEP+=("--queue" "$TARGET")
-set -- "${KEEP[@]}"
-echo "-------Starting with ${KEEP[@]}"
+define_queue $1
+if [ "X$QUEUE" != "X" ]; then
+  echo $QUEUE
+  exit 0
+else
+  if [ "X$1" == "X" ]; then
+    echo "Error: No matching rule."
+    exit 2
+  else
+    echo "Error: No matching queue."
+    exit 3
+  fi
+fi 


### PR DESCRIPTION
Use alternatives to prioritize the pnda spark cli wrapper (which
implements the pnda queue placement policy) over the default spark cli.
This allows frameworks that use the default system cli to benefit from the
pnda queue placement policy.