### PR TITLE
PNDA-3126: Create files from multiple Kafka partitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3527: Add dev/prod queues to YARN CDH config.
 - PNDA-3528: Add some pillars for the resource manager and used in the dm-config.
 - PNDA-2834: Actual application status by deployment manager
+- PNDA-3126: Create files from multiple Kafka partitions.
 
 ### Changed
 - PNDA-3545: Configure Hive and Hive2 Ambari views to run as the hdfs super user

--- a/salt/gobblin/templates/mr.pull.tpl
+++ b/salt/gobblin/templates/mr.pull.tpl
@@ -13,7 +13,7 @@ job.description=Pulls data from all kafka topics to HDFS
 mr.job.max.mappers={{ max_mappers }}
 
 # ==== Kafka Source ====
-source.class=gobblin.source.extractor.extract.kafka.KafkaSimpleSource
+source.class=gobblin.source.extractor.extract.kafka.KafkaDeserializerSource
 source.timezone=UTC
 source.schema={"namespace": "pnda.entity",                 \
                "type": "record",                            \
@@ -25,6 +25,9 @@ source.schema={"namespace": "pnda.entity",                 \
                    {"name": "rawdata",   "type": "bytes"}   \
                ]                                            \
               }
+
+kafka.deserializer.type=BYTE_ARRAY
+kafka.workunit.packer.type=BI_LEVEL
 
 kafka.brokers={{ kafka_brokers|join(",") }}
 bootstrap.with.offset=earliest


### PR DESCRIPTION
# Problem Statement:
PNDA-3126: Create files from multiple Kafka partitions.

# Analysis:
1. Current gobblin job to ingest Kafka data to HDFS uses KafkaSimpleSource which simply returns a byte[], which is just a black-box of data. Changed kafka source to KafkaDeserializerSource as Kafka's Deserializer interface offers a generic interface for Kafka Clients to deserialize data from Kafka into Java Objects.
2. In case of multiple partitions of same topic, the current gobblin job resulted in creation of many small output files as multiple partitions of a topic are assigned to different mappers, hence they cannot share output files. Added BI-LEVEL packing which groups the workunits resulting in reduced number of files and tasks. 
3. These changes also help in optimizing resource utilization for job execution, job execution time, file size written to HDFS and number of HDFS read/write operations.

# Changes:
Modified gobblin job template to use Kafka Deserializer as kafka source class and set deserilaizer type to byte array. Added grouping workunits type to BI-LEVEL to reduces number of output files.

# Pre-requisite:
PNDA-3133: Remove Gobblin fork and use release distribution instead - **To be merged.**