### PR TITLE
PNDA-2834: Actual application status by deployment manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3548: Upgrade Kafka manager to version 1.3.3.15
 - PNDA-3527: Add dev/prod queues to YARN CDH config.
 - PNDA-3528: Add some pillars for the resource manager and used in the dm-config.
+- PNDA-2834: Actual application status by deployment manager
 
 ### Changed
 - PNDA-3545: Configure Hive and Hive2 Ambari views to run as the hdfs super user

--- a/salt/deployment-manager/init.sls
+++ b/salt/deployment-manager/init.sls
@@ -99,12 +99,35 @@ deployment-manager-copy_service:
     - defaults:
         install_dir: {{ install_dir }}
 
+dm-application-summary-copy_service:
+  file.managed:
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /etc/init/dm-application-summary.conf
+    - source: salt://deployment-manager/templates/dm-application-summary.conf.tpl
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - name: /usr/lib/systemd/system/dm-application-summary.service
+    - source: salt://deployment-manager/templates/dm-application-summary.service.tpl
+{% endif %}
+    - template: jinja
+    - defaults:
+        install_dir: {{ install_dir }}
+
 {% if grains['os'] in ('RedHat', 'CentOS') %}
 deployment-manager-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload; /bin/systemctl enable deployment-manager
 {%- endif %}
 
+{% if grains['os'] in ('RedHat', 'CentOS') %}
+dm-application-summary-systemctl_reload:
+  cmd.run:
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable dm-application-summary
+{%- endif %}
+
 deployment-manager-start_service:
   cmd.run:
     - name: 'service deployment-manager stop || echo already stopped; service deployment-manager start'
+
+dm-application-summary-start_service:
+  cmd.run:
+    - name: 'service dm-application-summary stop || echo already stopped; service dm-application-summary start'

--- a/salt/deployment-manager/templates/dm-application-summary.conf.tpl
+++ b/salt/deployment-manager/templates/dm-application-summary.conf.tpl
@@ -1,0 +1,12 @@
+start on runlevel [2345]
+stop on runlevel [016]
+
+normal exit 0
+respawn
+respawn limit unlimited
+post-stop exec sleep 2
+
+env PYTHON_HOME={{ install_dir }}/deployment_manager/venv
+
+chdir {{ install_dir }}/deployment_manager
+exec ${PYTHON_HOME}/bin/python application_summary.py

--- a/salt/deployment-manager/templates/dm-application-summary.service.tpl
+++ b/salt/deployment-manager/templates/dm-application-summary.service.tpl
@@ -1,0 +1,12 @@
+[Unit]
+Description=deployment manager service
+
+[Service]
+Type=simple
+WorkingDirectory={{ install_dir }}/deployment_manager
+ExecStart={{ install_dir }}/deployment_manager/venv/bin/python {{ install_dir }}/deployment_manager/application_summary.py
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Problem Statement:
PNDA-2834: Currently deployment manager providing the status based on start / stop button action in UI and it is not providing the actual status where the application was executed.

## Analysis:
- Platform-deployment-manager has three component handler
	- OOZIE
	- SPARK-STREAMING
	- JUPYTER
- Jobs will be submitted to YARN for execution
- OOZIE, YARN and SPARK-STREAMING can provide status for applications
- Need to create a python job that will query OOZIE, YARN and SPARK,
  for application's actual status

## Approach:
- Get list of application from existing “platform_applications” HBase table
- For each application get create data and calculate the total number of component present in all the applications
- Components of applications will be processed in multiprocessing environment for that process count will be calculated based on the formula below
````
                     total component count *  max  time for processing  single  component  (max 6 seconds)
Process  Count = ----------------------------------------------------------------------------------------------
                                       total time-bound( Currently 60 seconds )
````
- If calculated process count exceeds 4, set process count to 4
- Components will be processed based on its type OOZIE and SPARK STREAMING
- After components processed build aggregate status based on component's status for all application
- Once aggregate status built for all application, post it to HBase 
- Above steps will be executed in an infinite loop with an interval of 60 seconds

## Changes:
- platform-deployment-manager
  - Created a python job that will have the described approach  
  - Created a python file that will post summary data to HBase and get summary data from HBase
  - Added a new API /summary to provide summary status built for every application that will be fetched from HBase
  
  Files added:
  - platform-deployment-manager/api/src/main/resources/application_summary.py
  - platform-deployment-manager/api/src/main/resources/application_summary_registrar.py
  - platform-deployment-manager/api/src/main/resources/test_application_summary.py
  - platform-deployment-manager/api/src/main/resources/test_application_summary_registrar.py
  
  Files modified:
  - platform-deployment-manager/api/src/main/resources/app.py
  - platform-deployment-manager/api/src/main/resources/deployment-manager.py
  - platform-deployment-manager/api/src/main/resources/lifecycle-states.py
  - platform-deployment-manager/api/src/main/resources/test_deployer_manager.py
  
- platform-salt
  - Created a daemon for python job created in platform-deployment-manager
  
  Files added:
  - platform-salt/salt/deployment-manager/templates/dm-application-summary.conf.tpl
  - platform-salt/salt/deployment-manager/templates/dm-application-summary.service.tpl
  
  Files modified:
  - platform-salt/salt/deployment-manager/init.sls
  
- platform-console-backend
  - Added /summary API to get summary status from deployment manager
  
  Files modified:
  - platform-console-backend/console-backend-data-manager/routes/applications.js

## Test details:
Verified the Changes in
- UBUNTU-PICO - CDH & HDP
- UBUNTU-STD - CDH & HDP
- RHEL-PICO - CDH & HDP
- RHEL-STD - CDH & HDP
