### PR TITLE
PNDA-3127: Post ingress aggregation for Kafka datasets.

### DIFF
--- a/pillar/pnda.sls
+++ b/pillar/pnda.sls
@@ -9,6 +9,7 @@ pnda:
     directory: /user/pnda/PNDA_datasets/datasets
     quarantine_directory: /user/pnda/PNDA_datasets/quarantine
     bulk_directory: /user/pnda/PNDA_datasets/bulk
+    staging_directory: /user/pnda/PNDA_datasets/staging
   
   app_packages:
     app_packages_hdfs_path: /pnda/deployment/app_packages

--- a/salt/gobblin/init.sls
+++ b/salt/gobblin/init.sls
@@ -22,6 +22,17 @@
 {% set pnda_quarantine_dataset_location = pillar['pnda']['master_dataset']['quarantine_directory'] %}
 {% set pnda_quarantine_kite_dataset_uri = "dataset:" + namenode + pnda_quarantine_dataset_location %}
 
+{% set pnda_staging_dataset_location = pillar['pnda']['master_dataset']['staging_directory'] %}
+{% set pnda_kite_staging_dataset_uri = "dataset:" + namenode + pnda_staging_dataset_location %}
+{% set perform_compaction = salt['pillar.get']('dataset_compaction:compaction', False) %}
+
+{% if perform_compaction %}
+{% set compaction_pattern = salt['pillar.get']('dataset_compaction:pattern', 'd') %}
+{% set pnda_primary_dataset_uri = pnda_kite_staging_dataset_uri %}
+{% else %}
+{% set pnda_primary_dataset_uri = pnda_kite_dataset_uri %}
+{%- endif %}
+
 {% set gobblin_hdfs_work_dir = '/user/' + pnda_user + '/gobblin/work' %}
 
 {% if grains['hadoop.distro'] == 'HDP' %}
@@ -73,12 +84,27 @@ gobblin-install_gobblin_pnda_job_file:
     - template: jinja
     - context:
       namenode: {{ namenode }}
-      kite_dataset_uri: {{ pnda_kite_dataset_uri }}
+      kite_dataset_uri: {{ pnda_primary_dataset_uri }}
       quarantine_kite_dataset_uri: {{ pnda_quarantine_kite_dataset_uri }}
       kafka_brokers: {{ kafka_brokers }}
       max_mappers: {{ flavor_cfg.max_mappers }}
     - require:
       - file: gobblin-create_gobblin_jobs_directory
+
+{% if perform_compaction %}
+gobblin-install_gobblin_pnda_compaction_job_file:
+  file.managed:
+    - name: {{ gobblin_link_dir }}/configs/mr.compact
+    - source: salt://gobblin/templates/mr.compact.tpl
+    - template: jinja
+    - context:
+      namenode: {{ namenode }}
+      staging_dataset_location: {{ pnda_staging_dataset_location }}
+      master_dataset_location: {{ pnda_master_dataset_location }}
+      max_mappers: {{ flavor_cfg.max_mappers }}
+    - require:
+      - file: gobblin-create_gobblin_jobs_directory
+{%- endif %}
 
 gobblin-create_gobblin_logs_directory:
   file.directory:
@@ -103,6 +129,25 @@ gobblin-install_gobblin_service_script:
       gobblin_job_file: {{ gobblin_link_dir }}/configs/mr.pull
       hadoop_home_bin: {{ hadoop_home_bin }}
 
+{% if perform_compaction %}
+gobblin-install_gobblin_compact_service_script:
+  file.managed:
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /etc/init/gobblin-compact.conf
+    - source: salt://gobblin/templates/gobblin-compact.conf.tpl
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - name: /usr/lib/systemd/system/gobblin-compact.service
+    - source: salt://gobblin/templates/gobblin-compact.service.tpl
+{%- endif %}
+    - template: jinja
+    - context:
+      gobblin_directory_name: {{ gobblin_link_dir }}/gobblin-dist
+      gobblin_user: {{ pnda_user }}
+      gobblin_work_dir: {{ gobblin_hdfs_work_dir }}
+      gobblin_job_file: {{ gobblin_link_dir }}/configs/mr.compact
+      hadoop_home_bin: {{ hadoop_home_bin }}
+{%- endif %}
+
 {% if grains['os'] in ('RedHat', 'CentOS') %}
 gobblin-systemctl_reload:
   cmd.run:
@@ -121,3 +166,32 @@ gobblin-add_gobblin_crontab_entry:
     - minute: 0,30
     - require:
       - file: gobblin-install_gobblin_service_script
+
+{% if perform_compaction %}
+gobblin-add_gobblin_compact_crontab_entry:
+  cron.present:
+    - identifier: GOBBLIN-COMPACT
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /sbin/start gobblin-compact
+{% elif grains['os'] == 'RedHat' %}
+    - name: /bin/systemctl start gobblin-compact
+{%- endif %}
+    - user: root
+{% if compaction_pattern == 'H' %}
+    - minute: 0
+{% elif compaction_pattern == 'd' %}
+    - minute: 0
+    - hour: 1
+{% elif compaction_pattern == 'M' %}
+    - minute: 0
+    - hour: 1
+    - daymonth: 1
+{% elif compaction_pattern == 'Y' %}
+    - minute: 0
+    - hour: 1
+    - daymonth: 1
+    - month: 1
+{% endif %}
+    - require:
+      - file: gobblin-install_gobblin_compact_service_script
+{%- endif %}

--- a/salt/gobblin/templates/gobblin-compact.conf.tpl
+++ b/salt/gobblin/templates/gobblin-compact.conf.tpl
@@ -1,0 +1,13 @@
+description     "Linked-in Gobblin MRv2 application: PNDA pull"
+
+task
+
+umask 022
+setuid {{ gobblin_user }}
+
+env JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
+env HADOOP_BIN_DIR="{{ hadoop_home_bin }}"
+
+chdir {{ gobblin_directory_name }}
+
+exec bash ./bin/gobblin-compaction.sh --type mr --conf {{ gobblin_job_file }} --logdir /var/log/pnda/gobblin --workdir "{{ gobblin_work_dir }}" --jars $(ls lib/*.jar | tr '\n' ',')

--- a/salt/gobblin/templates/gobblin-compact.service.tpl
+++ b/salt/gobblin/templates/gobblin-compact.service.tpl
@@ -1,0 +1,10 @@
+[Unit]
+Description=Linked-in Gobblin MRv2 application: PNDA pull
+
+[Service]
+Type=oneshot
+UMask=022
+User=pnda
+Environment="JAVA_HOME=/usr/lib/jvm/java-8-oracle/" "HADOOP_BIN_DIR={{ hadoop_home_bin }}" "GOBBLIN_CONF_FILE=/opt/pnda/gobblin/configs/mr.compact" "GOBBLIN_LOG_DIR=/var/log/pnda/gobblin" "GOBBLIN_WORK_DIR=/user/pnda/gobblin/work" 'GOBBLIN_JARS=lib/*.jar'
+WorkingDirectory=/opt/pnda/gobblin/gobblin-dist
+ExecStart=/usr/bin/bash ./bin/gobblin-compaction.sh --type mr --conf $GOBBLIN_CONF_FILE --logdir $GOBBLIN_LOG_DIR --workdir $GOBBLIN_WORK_DIR --jars $GOBBLIN_JARS

--- a/salt/gobblin/templates/mr.compact.tpl
+++ b/salt/gobblin/templates/mr.compact.tpl
@@ -1,0 +1,44 @@
+
+###############################################################################
+###################### Gobblin Compaction Job configurations ##################
+###############################################################################
+
+{%- set compaction_pattern = salt['pillar.get']('dataset_compaction:pattern', 'd') %}
+{%- if compaction_pattern == 'H' %}
+{%- set folder_pattern="'year='YYYY/'month='MM/'day='dd/'hour='HH" %}
+{%- set time_ago='1d' %}
+{% elif compaction_pattern == 'd' %}
+{%- set folder_pattern="'year='YYYY/'month='MM/'day='dd" %}
+{%- set time_ago='1d2h' %}
+{% elif compaction_pattern == 'M' %}
+{%- set folder_pattern="'year='YYYY/'month='MM" %}
+{%- set time_ago='1m2h' %}
+{% elif compaction_pattern == 'Y' %}
+{%- set folder_pattern="'year='YYYY" %}
+{%- set time_ago='12m2h' %}
+{%- endif %}
+
+# File system URIs
+fs.uri={{ namenode }}
+writer.fs.uri=${fs.uri}
+
+job.name=CompactKafkaMR
+job.group=PNDA
+
+mr.job.max.mappers={{ max_mappers }}
+
+compaction.datasets.finder=gobblin.compaction.dataset.TimeBasedSubDirDatasetsFinder
+compaction.input.dir={{ staging_dataset_location }}
+compaction.dest.dir={{ master_dataset_location }}
+compaction.input.subdir=.
+compaction.dest.subdir=.
+compaction.timebased.folder.pattern={{ folder_pattern }}
+compaction.timebased.max.time.ago={{ time_ago }}
+compaction.timebased.min.time.ago=1h
+compaction.input.deduplicated=false
+compaction.output.deduplicated=false
+compaction.jobprops.creator.class=gobblin.compaction.mapreduce.MRCompactorTimeBasedJobPropCreator
+compaction.job.runner.class=gobblin.compaction.mapreduce.avro.MRCompactorAvroKeyDedupJobRunner
+compaction.timezone=UTC
+compaction.job.overwrite.output.dir=true
+compaction.recompact.from.input.for.late.data=true

--- a/salt/master-dataset/init.sls
+++ b/salt/master-dataset/init.sls
@@ -11,6 +11,9 @@
 {% set pnda_quarantine_dataset_location = pillar['pnda']['master_dataset']['quarantine_directory'] %}
 {% set pnda_quarantine_kite_dataset_uri = "dataset:" + namenode + pnda_quarantine_dataset_location %}
 
+{% set pnda_staging_dataset_location = pillar['pnda']['master_dataset']['staging_directory'] %}
+{% set pnda_kite_staging_dataset_uri = "dataset:" + namenode + pnda_staging_dataset_location %}
+
 {% set pnda_mirror = pillar['pnda_mirror']['base_url'] %}
 {% set misc_packages_path = pillar['pnda_mirror']['misc_packages_path'] %}
 {% set mirror_location = pnda_mirror + misc_packages_path %}
@@ -70,6 +73,24 @@ master-dataset-update_PNDA_master_kite_dataset_perms:
     - user: hdfs
     - onchanges:
       - cmd: master-dataset-create_PNDA_master_kite_dataset
+
+{%if salt['pillar.get']('dataset_compaction:compaction', False) %}
+master-dataset-create_PNDA_staging_kite_dataset:
+  cmd.run:
+    - name: kite-dataset create --schema /tmp/pnda.avsc {{ pnda_kite_staging_dataset_uri }} --partition-by /tmp/pnda_kite_partition.json
+    - user: {{ pnda_user }}
+    - unless: kite-dataset info {{ pnda_kite_staging_dataset_uri }}
+    - requires:
+      - file: master-dataset_copy_pnda_avro_schema
+      - file: master-dataset_copy_kite_parition_conf
+
+master-dataset-update_PNDA_staging_kite_dataset_perms:
+  cmd.run:
+    - name: hdfs dfs -chmod 770 {{ pnda_staging_dataset_location }}
+    - user: hdfs
+    - onchanges:
+      - cmd: master-dataset-create_PNDA_staging_kite_dataset
+{% endif %}
 
 master-dataset-quarantine_dataset_copy_avro_schema:
   file.managed:


### PR DESCRIPTION
1. Gobblin Compaction-

*******************
1.1. Brief
--Compaction strategy will be set at deployment level
--If compaction is enabled, datasets from pull job will be stored in a different directory - /user/pnda/PNDA_datasets/hourly_staging/
--Compaction strategy will apply to all the datasets (system wide)
--User at the time of deployment will be able to control following parameters w.r.t. compaction
---Enable/Disable compaction
---Level of compaction <Hourly(H), Daily(d), Monthly(M), Yearly(Y)>
---Archive or delete hourly_staging data

**Note: when the datasets would appear in master dataset (/user/pnda/PNDA_datasets/datasets) will depend on the level of compaction. For instance in case of hourly compaction  it will appear 
after a lag of 2 hours from the time it was pulled into hourly_staging, for daily compaction after a lag 1 day and so on.


1.2. At deployment level, using pnda-cli/pnda_env.yaml user can enable/disable compaction, defaults to disable.
Compaction properties will apply system wide and not per dataset. 

pnda-cli/pnda_env.yaml

dataset_compaction:
    compaction: "YES"
    level: H
    retention_mode: delete

1.2.1 Parameters-

compaction - To enable/disable compaction: "YES"/"NO"
level - To set compaction strategy: H - hourly, d - daily, M - monthly, Y - yearly
retention_mode - Manage staging data once compaction is complete on it: archive/delete

1.3. Compaction behavior
Case #1.3.1. compaction is set to "NO"
--No compaction will be performed 
--Pull job will submit data to /user/pnda/PNDA_datasets/datasets/

Case #1.3.2. compaction is "YES"
--compaction will be performed 
--Pull job will submit data to /user/pnda/PNDA_datasets/staging/
--compaction job will run on data in staging directory. compacted data will be stored in /user/pnda/PNDA_datasets/datasets/

Case #1.3.2.1. level: H
--Compaction job will run every hour
--Will compact data not older than 1 day and which is not being generated in past 1 hour
--Staging data older than 2 days will be deleted/archived

Case #1.3.2.1.2. level: d
--Compaction job will run once a day
--Will compact data not older than 1 day and which is not being generated in past 1 hour
--Staging data older than 2 days will be deleted/archived

Case #1.3.2.1.3. level: M
--Compaction job will run once a month
--Will compact data not older than 1 month and which is not being generated in past 1 hour
--Staging data older than 32 days will be deleted/archived

Case #1.3.2.1.4. level: Y
--Compaction job will run once a year
--Will compact data not older than 1 year and which is not being generated in past 1 hour
--Staging data older than 367 days will be deleted/archived


**********************
2. hourly_staging data clean up
--Will be performed by hdfs-cleaner based on parameter set in properties.json.
--properties.json will be updated based on level and retention_mode provided in pnda.sls


**********************
3. Cron configuration

case #3.1. level: H
0 * * * * 	

case #3.2. level: d
0 1 * * * 	

case #3.3. level: M
0 1 1 * * 	

case #3.4. level: Y
0 1 1 1 *  

**********************
PNDA-3127 has dependency upon PNDA-3133