### PR TITLE
PNDA-3133: Remove Gobblin fork and use release distribution instead.

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -55,6 +55,9 @@ jupyterproxy:
   release_version: 1.3.1
 
 gobblin:
+  release_version: 0.11.0
+
+platform_gobblin_modules:
   release_version: develop
 
 console_frontend:


### PR DESCRIPTION
# Problem Statement:
- PNDA-3133: Remove Gobblin fork and use release distribution instead.
- Fix for Issue- #390

# Analysis:
- currently, as not a upstream project the release version for gobblin is develop.
- The version of gobblin being deployed is only compiled against the CDH distribution.
- The gobblin job is not executing successfuly because gobblin-current.log file is not created/available to write the logs.
- the data-x.x.x.jar - the actual file version ( 11.0.0 ) and gobblin-mapreduce.sh reference( from older release - 2.6.0 ) are mismatching.

# Change:
- Changed the release version to latest one i.e. 0.11.0
- Deploying the gobblin corresponding to CDH and HDP available on Mirror Server.
- Created the log file for gobblin job execution.
- updated the data-x.x.x.jar file version appropriately.

# Test details:
Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
Verification pending for OpenStack.