### PR TITLE
PNDA-3582: Create a mapping table for PNDA-3526.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3600: Make the spark/MR cli wrapper the master system cli.
 - PNDA-3581: Create a mapping table for the Fair Scheduler queue setup (CDH) of PNDA-3527.
 - PNDA-3529: Make Jupyter use the system spark cli.
+- PNDA-3582: Create a mapping table for the Capacity Scheduler queue setup (HDP) from PNDA-3526.
 
 ### Fixed
 - PNDA-3573: remove eth0 default value on kafka

--- a/salt/resource-manager/templates/capacity_scheduler_map.txt
+++ b/salt/resource-manager/templates/capacity_scheduler_map.txt
@@ -11,5 +11,12 @@
 # when the user is empty (second rule above), the whole group will be mapped to the queue
 # when both the user and the group are defined, the group will be ignored
 
-# Every user will be mapped to the default queue.
-* default
+# The 'pnda' user will be mapped to the default queue.
+pnda: default
+
+# The 'prod' group users will be mapped to the prod queue unless the dev queue is explicitly requested.
+:prod prod
+:prod dev
+
+# The 'dev' group users will be mapped to the dev queue. 
+:dev dev


### PR DESCRIPTION
PNDA-3526 introduces a Capacity Scheduler queue setup that requires
an associated queue placement.
This patch creates that mapping table for the Capacity Scheduler.