### PR TITLE
Run hdfs-sync idempotently on PNDA edge after pip sync

### DIFF
--- a/salt/app-packages/hdfs-sync.sls
+++ b/salt/app-packages/hdfs-sync.sls
@@ -5,13 +5,19 @@
 {% set app_packages_fs_path = pnda_home + "/apps-packages" %}
 {% set mirror_url = pnda_mirror + app_packages_mirror_path %}
 
-app-packages-hdfs-sync_instantiate-package-list:
+app-packages-create-directory:
+  file.directory:
+    - name: {{ app_packages_fs_path }}
+    - mode: 755
+    - makedirs: True
+
+app-packages-instantiate-package-list:
   file.managed:
     - name: {{ app_packages_fs_path }}/app-packages-hdfs.txt
     - source: salt://app-packages/files/app-packages-hdfs.txt
     - template: jinja
 
-app-packages-hdfs-sync_sync-hdfs:
+app-packages-sync-hdfs:
   cmd.script:
     - name: salt://app-packages/templates/sync.sh.tpl
     - template: jinja

--- a/salt/app-packages/init.sls
+++ b/salt/app-packages/init.sls
@@ -1,10 +1,6 @@
 {% set pnda_home = pillar['pnda']['homedir'] %}
-{% set pnda_mirror = pillar['pnda_mirror']['base_url'] %}
 {% set pip_index_url = pillar['pip']['index_url'] %}
 {% set app_packages_hdfs_path = pillar['pnda']['app_packages']['app_packages_hdfs_path'] %}
-{% set app_packages_mirror_path = pillar['pnda_mirror']['app_packages_path'] %}
-{% set app_packages_fs_path = pnda_home + "/apps-packages" %}
-{% set mirror_url = pnda_mirror + app_packages_mirror_path %}
 
 include:
   - python-pip
@@ -21,26 +17,3 @@ app-packages-create-venv:
 app-packages-initialize-hdfs:
   cmd.run:
     - name: 'sudo -u hdfs hdfs dfs -mkdir -p {{ app_packages_hdfs_path }}'
-
-app-packages-create-directory:
-  file.directory:
-    - name: {{ app_packages_fs_path }}
-    - mode: 755
-    - makedirs: True
-
-app-packages-instantiate-package-list:
-  file.managed:
-    - name: {{ app_packages_fs_path }}/app-packages-hdfs.txt
-    - source: salt://app-packages/files/app-packages-hdfs.txt
-    - template: jinja
-
-app-packages-sync-hdfs:
-  cmd.script:
-    - name: salt://app-packages/templates/sync.sh.tpl
-    - template: jinja
-    - context:
-        app_packages_hdfs_path : {{ app_packages_hdfs_path }}
-        mirror_url: {{ mirror_url }}
-        app_packages_fs_path: {{ app_packages_fs_path }}/app-packages-hdfs.txt
-    - cwd: {{ app_packages_fs_path }}
-

--- a/salt/app-packages/templates/sync.sh.tpl
+++ b/salt/app-packages/templates/sync.sh.tpl
@@ -15,7 +15,7 @@ do
     echo "Uploading new package ${c}"
     curl -fsO {{ mirror_url }}/$c
     [[ $? -ne 0 ]] && echo "Error downloading ${c} from mirror" && exit -1
-    sudo -u hdfs hdfs dfs -put $c {{ app_packages_hdfs_path }}/
+    sudo -u hdfs hdfs dfs -put -f $c {{ app_packages_hdfs_path }}/
     [[ $? -ne 0 ]] && echo "Error uploading ${c} to HDFS" && exit -1
   fi
 done

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -246,6 +246,14 @@ orchestrate-pnda-app-packages:
     - timeout: 120
     - queue: True
 
+orchestrate-pnda-app-packages-hdfs:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and ( G@roles:hadoop_edge )'
+    - tgt_type: compound
+    - sls: app-packages.hdfs-sync
+    - timeout: 120
+    - queue: True
+
 orchestrate-pnda-install_remove_new_node_markers:
   salt.state:
     - tgt: 'G@pnda_cluster:{{pnda_cluster}}'


### PR DESCRIPTION
The hdfs-sync tool needs to run once during provisioning on the edge node, but PNDA has multiple hadoop edge nodes in some flavors. This change targets the PNDA edge node (as there is only one across all flavors at present) but also improves the idempotency of the hdfs-sync tool to make more robust against race conditions that could show up in future if we add additional PNDA edge nodes.
This change also reverts the refactoring carried out recently as this is no longer necessary.

PNDA-3655