### PR TITLE
PNDA-4028: Compaction isn't compressing final output file

### DIFF
--- a/salt/gobblin/templates/mr.compact.tpl
+++ b/salt/gobblin/templates/mr.compact.tpl
@@ -42,3 +42,4 @@ compaction.job.runner.class=gobblin.compaction.mapreduce.avro.MRCompactorAvroKey
 compaction.timezone=UTC
 compaction.job.overwrite.output.dir=true
 compaction.recompact.from.input.for.late.data=true
+mapred.output.compress=true


### PR DESCRIPTION
Output file will get compressed using default hadoop config parameters(codec: DEFLATE, type: BLOCK)