### PR TITLE
PNDA-1322: Test Master Dataset Health

### DIFF
--- a/salt/gobblin/init.sls
+++ b/salt/gobblin/init.sls
@@ -186,19 +186,6 @@ gobblin-systemctl_reload:
     - name: /bin/systemctl daemon-reload
 {%- endif %}
 
-gobblin-add_gobblin_crontab_entry:
-  cron.present:
-    - identifier: GOBBLIN
-{% if grains['os'] == 'Ubuntu' %}
-    - name: /sbin/start gobblin
-{% elif grains['os'] in ('RedHat', 'CentOS') %}
-    - name: /bin/systemctl start gobblin
-{%- endif %}
-    - user: root
-    - minute: 0,30
-    - require:
-      - file: gobblin-install_gobblin_service_script
-
 {% if perform_compaction %}
 gobblin-add_gobblin_compact_crontab_entry:
   cron.present:

--- a/salt/gobblin/initial_gobblin_run.sls
+++ b/salt/gobblin/initial_gobblin_run.sls
@@ -1,0 +1,32 @@
+gobblin-require_gobblin_service_script:
+  file.exists:
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /etc/init/gobblin.conf
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - name: /usr/lib/systemd/system/gobblin.service
+{%- endif %}
+
+{% if grains['os'] == 'Ubuntu' %}
+gobblin-sbin_ubuntu_start:
+  cmd.run:
+    - name: /sbin/start gobblin
+{% elif grains['os'] == 'RedHat' %}
+gobblin-systemctl_redhat_start:
+  cmd.run:
+    - name: /bin/systemctl start gobblin
+{%- endif %}
+    - require:
+      - file: gobblin-require_gobblin_service_script 
+
+gobblin-add_gobblin_crontab_entry:
+  cron.present:
+    - identifier: GOBBLIN
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /sbin/start gobblin
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - name: /bin/systemctl start gobblin
+{%- endif %}
+    - user: root
+    - minute: 0,30
+    - require:
+      - file: gobblin-require_gobblin_service_script

--- a/salt/gobblin/templates/mr.pull.tpl
+++ b/salt/gobblin/templates/mr.pull.tpl
@@ -48,6 +48,4 @@ metrics.reporting.file.enabled=true
 # ==== Blacklist topics ====
 # Recent Kafka version uses internal __consumer_offsets topic, which we don't
 # want to ingest
-# Don't ingest the avro.internal.testbot topic as it's only an internal PNDA
-# testing topic
-topic.blacklist=__consumer_offsets,avro.internal.testbot
+topic.blacklist=__consumer_offsets

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -261,3 +261,11 @@ orchestrate-pnda-install_remove_new_node_markers:
     - sls: orchestrate.remove_new_node_marker
     - timeout: 120
     - queue: True
+
+orchestrate-pnda-initial_gobblin_run:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@roles:gobblin'
+    - tgt_type: compound
+    - sls: gobblin.initial_gobblin_run
+    - timeout: 120
+    - queue: True

--- a/salt/platform-testing/general.sls
+++ b/salt/platform-testing/general.sls
@@ -12,6 +12,16 @@
 {% set zookeeper_port = '2181' %}
 {% set dm_port = '5000' %}
 {% set opentsdb_port = '4242' %}
+{% set elk_port = '9200' %}
+{% set data_service_port = '7000' %}
+{% set metric_console_port = '3123' %}
+{% set gobblin_cron_interval = 30 %}
+{% set gobblin_retry_count = 11 %}
+{% set gobblin_log_path = '/var/log/pnda/gobblin/gobblin_current.log' %}
+{% set pnda_master_dataset_location = pillar['pnda']['master_dataset']['directory'] %}
+{% set pnda_quarantine_dataset_location = pillar['pnda']['master_dataset']['quarantine_directory'] %}
+{% set console_user = pillar['pnda']['user'] %}
+{% set console_password = pillar['pnda']['password'] %}
 
 {% set pnda_cluster = salt['pnda.cluster_name']() %}
 
@@ -30,9 +40,21 @@
 {%- do opentsdb_hosts.append(ip + ':' + opentsdb_port) -%}
 {%- endfor -%}
 
+{%- set data_service_hosts = [] -%}
+{%- for ip in salt['pnda.ip_addresses']('data_service') -%}
+{%- do data_service_hosts.append("http://" + ip + ':' + data_service_port) -%}
+{%- endfor -%}
+
+{%- set elk_hosts = [] -%}
+{%- for ip in salt['pnda.ip_addresses']('kibana_dashboard') -%}
+{%- do elk_hosts.append("http://" + ip + ':' + elk_port) -%}
+{%- endfor -%}
+
 {%- set console_hosts = [] -%}
+{%- set metric_console_hosts = [] -%}
 {%- for ip in salt['pnda.ip_addresses']('console_backend_data_logger') -%}
 {%- do console_hosts.append(ip + ':' + console_port) -%}
+{%- do metric_console_hosts.append("http://" + ip + ':' + metric_console_port) -%}
 {%- endfor -%}
 
 {%- set dm_hosts = [] -%}
@@ -197,6 +219,43 @@ platform-testing-general-crontab-opentsdb:
     - name: /sbin/start platform-testing-general-opentsdb
 {% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-general-opentsdb
+{% endif %}
+
+platform-testing-general-dataset_service:
+  file.managed:
+{% if grains['os'] == 'Ubuntu' %}
+    - source: salt://platform-testing/templates/platform-testing-general-dataset.conf.tpl
+    - name: /etc/init/platform-testing-general-dataset.conf
+{% elif grains['os'] == 'RedHat' %}
+    - name: /usr/lib/systemd/system/platform-testing-general-dataset.service
+    - source: salt://platform-testing/templates/platform-testing-general-dataset.service.tpl
+{% endif %}
+    - mode: 644
+    - template: jinja
+    - context:
+      platform_testing_directory: {{ platform_testing_directory }}
+      platform_testing_package: {{ platform_testing_package }}
+      console_hosts: {{ console_hosts }}
+      data_service_hosts: {{ data_service_hosts }}
+      metric_console_hosts: {{ metric_console_hosts }}
+      pnda_cluster: {{ pnda_cluster }}
+      elk_hosts: {{ elk_hosts }}
+      gobblin_cron_interval: {{ gobblin_cron_interval }}
+      gobblin_log_path: {{ gobblin_log_path }}
+      gobblin_retry_count: {{ gobblin_retry_count }}
+      pnda_master_dataset_location: {{ pnda_master_dataset_location }}
+      pnda_quarantine_dataset_location: {{ pnda_quarantine_dataset_location }}
+      console_user: {{ console_user }}
+      console_password: {{ console_password }}
+
+platform-testing-general-crontab-dataset:
+  cron.present:
+    - identifier: PLATFORM-TESTING-DATASET
+    - user: root
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /sbin/start platform-testing-general-dataset
+{% elif grains['os'] == 'RedHat' %}
+    - name: /bin/systemctl start platform-testing-general-dataset
 {% endif %}
 
 {%- if dm_hosts is not none and dm_hosts|length > 0 %}

--- a/salt/platform-testing/templates/platform-testing-general-dataset.conf.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-dataset.conf.tpl
@@ -1,0 +1,8 @@
+description "Platform testing general dataset upstart script"
+author      "PNDA team"
+start on runlevel [2345]
+task
+env PYTHON_HOME={{ platform_testing_directory }}/{{platform_testing_package}}/venv
+exec ${PYTHON_HOME}/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin dataset --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--data_service {{ data_service_hosts|join(',') }} --cluster_name {{ pnda_cluster }} --elk_ip {{ elk_hosts|join(',') }} --cron_interval {{ gobblin_cron_interval }} --gobblin_log_path {{ gobblin_log_path }} --metric_console {{ metric_console_hosts|join(',') }} --num_attempts {{ gobblin_retry_count }} --master_dataset_dir {{ pnda_master_dataset_location }} --quarantine_dir {{ pnda_quarantine_dataset_location }} --console_user {{ console_user }} --console_password {{ console_password }}"
+
+

--- a/salt/platform-testing/templates/platform-testing-general-dataset.service.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-dataset.service.tpl
@@ -1,0 +1,8 @@
+[Unit]
+Description=Platform testing general dataset
+
+[Service]
+Type=oneshot
+ExecStart={{ platform_testing_directory }}/{{platform_testing_package}}/venv/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin dataset --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--data_service {{ data_service_hosts|join(',') }} --cluster_name {{ pnda_cluster }} --elk_ip {{ elk_hosts|join(',') }} --cron_interval {{ gobblin_cron_interval }} --gobblin_log_path {{ gobblin_log_path }} --metric_console {{ metric_console_hosts|join(',') }} --num_attempts {{ gobblin_retry_count }} --master_dataset_dir {{ pnda_master_dataset_location }} --quarantine_dir {{ pnda_quarantine_dataset_location }} --console_user {{ console_user }} --console_password {{ console_password }}"
+
+


### PR DESCRIPTION
# Problem Statement:
PNDA-1322: Test Master Dataset Health

# Analysis:
1.  Run Gobblin service manually(Before CRON Job run) to test Gobblin health initially
2.  Add CRON tab entry for Gobblin after initial Gobblin run
3.  Remove KAFKA internal test topic from blacklist in Gobblin configuration file
4.  Create service file and add CRON tab entry to run plugin(dataset) in platform-testing to test Master 
     Dataset Health

# Approach:
1. Add state file inside Gobblin directory to run Gobblin service manually
2. Add CRON tab entry for Gobblin after executing Gobblin service initially to avoid simultaneous runs
3. In order to test Dataset creation remove KAFKA internal test topic from Gobblin's blacklist
4. Add additional steps in platform-testing state to create service file and schedule CRON job to run 
    dataset plugin(To test Master Dataset Health)

# Test details:
UBUNTU-PICO-CDH
UBUNTU-STD-CDH
UBUNTU-PICO-HDP
UBUNTU-STD-HDP
RHEL-PICO-CDH
RHEL-STD-CDH
RHEL-PICO-HDP
RHEL-STD-HDP