### PR TITLE
PNDA-4226: Improve Session handling

### DIFF
--- a/salt/console-backend/templates/backend_data_manager_conf.js.tpl
+++ b/salt/console-backend/templates/backend_data_manager_conf.js.tpl
@@ -25,6 +25,7 @@ module.exports = {
   },
   session: {
     secret: "data-manager-secret",
-    max_age: 86400000
+    max_age: 86400000,
+    session_expiry_warning_duration: 30000
   }
 };


### PR DESCRIPTION
# Problem Statement:
- PNDA 4226: Session expiration on no activity for x (max age) time.

# Analysis:
- Currently session timeout or max age is set for one day.
- Session expires after one day irrespective of user is active or not.

# Change:
- Add session_expiry_warning_duration parameter in session