### PR TITLE
Remove ipv6 dependency in nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - PNDA-4200: Fix missing matplotlib and dependencies for Jupyter python3 kernel
+- PNDA-4399: Remove IPV6 dependency in nginx
 
 ## [4.0.0] 2018-02-10
 ### Added

--- a/salt/console-frontend/templates/PNDA_nginx.conf.tpl
+++ b/salt/console-frontend/templates/PNDA_nginx.conf.tpl
@@ -1,6 +1,5 @@
 server {
 	listen {{port}} default_server;
-	listen [::]:{{port}} default_server ipv6only=on;
 
 	root {{ console_dir }};
 	index index.html index.htm;


### PR DESCRIPTION
Remove IPv6 entry in nginx config that prevents it from starting on a system that explicitly denies ipv6.  