### PR TITLE
Use ntpdate to force ntp into sync

### DIFF
--- a/pillar/packages/CentOS.sls
+++ b/pillar/packages/CentOS.sls
@@ -82,6 +82,7 @@ nmap-ncat:
 ntp:
   package-name: ntp
   version: ""
+  service_name: ntpd
 opentsdb:
   package-source: 'opentsdb-2.3.0.rpm'
   bind_port: 4242

--- a/pillar/packages/RedHat.sls
+++ b/pillar/packages/RedHat.sls
@@ -82,6 +82,7 @@ nmap-ncat:
 ntp:
   package-name: ntp
   version: ""
+  service_name: ntpd
 opentsdb:
   package-source: 'opentsdb-2.3.0.rpm'
   bind_port: 4242

--- a/pillar/packages/Ubuntu.sls
+++ b/pillar/packages/Ubuntu.sls
@@ -67,6 +67,7 @@ nginx:
 ntp:
   package-name: ntp
   version: ""
+  service_name: ntp
 opentsdb:
   package-source: 'opentsdb-2.3.0_all.deb'
   bind_port: 4242

--- a/salt/ntp/files/ntpdate.sh
+++ b/salt/ntp/files/ntpdate.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+service {{ ntp_service }} stop || echo already stopped
+ntpdate {{ ntp_servers|join(" ") }}
+service {{ ntp_service }} start

--- a/salt/ntp/init.sls
+++ b/salt/ntp/init.sls
@@ -1,5 +1,6 @@
 {% set ntp_servers = salt['pillar.get']('ntp:servers', []) %}
 {% set timezone = salt['pillar.get']('ntp:timezone', 'UTC') %}
+{% set ntp_service = pillar['ntp']['service_name'] %}
 
 ntp-set_timezone:
   timezone.system:
@@ -19,10 +20,29 @@ ntp-install_conf:
     - context:
       ntp_servers: {{ ntp_servers }}
 
-ntp-start_service:
+ntp-ntpdate_sync_on_boot_script:
+  file.managed:
+    - name: /etc/ntpdate.sh
+    - source: salt://ntp/files/ntpdate.sh
+    - mode: 0755
+    - template: jinja
+    - context:
+      ntp_service: {{ ntp_service }}
+      ntp_servers: {{ ntp_servers }}
+
+{% if grains['os'] in ('RedHat', 'CentOS') %}
+ntp-systemctl_reload:
   cmd.run:
-    {% if grains['os'] in ('RedHat', 'CentOS') %}
-    - name: 'service ntpd stop || echo already stopped; service ntpd start'
-    {% elif grains['os'] == 'Ubuntu' %}
-    - name: 'service ntp stop || echo already stopped; service ntp start'
-    {% endif %}
+    - name: /bin/systemctl daemon-reload; /bin/systemctl enable {{ ntp_service }}; /bin/systemctl stop chronyd; /bin/systemctl disable chronyd; /bin/systemctl enable ntpdate;
+{%- else %}
+ntp-ntpdate_sync_on_boot_cmd:
+  file.append:
+    - name: /etc/rc.local
+    - text:
+      - "/etc/ntpdate.sh 2>&1 | tee -a /var/log/pnda/ntpdate_sync_on_boot.log"
+{%- endif %}
+
+ntp-ntpdate-sync:
+  cmd.run:
+    - name: '/etc/ntpdate.sh'
+


### PR DESCRIPTION
Run ntpdate in the ntp sls and also set it to run on system boot. On
RHEL the ntpdate service is available for this purpose, on Ubuntu
ntpdate is added to rc.local.
PNDA-4414

Also enable ntp to start on boot for rhel
PNDA-4421