### PR TITLE
PNDA-4431: Add basic platform test & console elements for Flink

### DIFF
--- a/salt/console-frontend/init.sls
+++ b/salt/console-frontend/init.sls
@@ -41,6 +41,7 @@
 {% set grafana_link = salt['pnda.generate_http_link']('grafana',':3000') %}
 {% set kibana_link = salt['pnda.generate_http_link']('logserver',':5601') %}
 {% set jupyter_link = salt['pnda.generate_external_link']('jupyter',':8000') %}
+{% set flink_link = salt['pnda.generate_external_link']('flink',':8082') %}
 {% set login_mode = 'PAM' %}
 
 include:
@@ -107,6 +108,7 @@ console-frontend-create_pnda_console_config:
         grafana_link: "{{ grafana_link }}"
         kibana_link: "{{ kibana_link }}"
         jupyter_link: "{{ jupyter_link }}"
+        flink_link: "{{ flink_link }}"
         login_mode: "{{ login_mode }}"
 
 # Create a configuration file for nginx and specify where the PNDA console file are

--- a/salt/console-frontend/templates/PNDA.json.tpl
+++ b/salt/console-frontend/templates/PNDA.json.tpl
@@ -26,6 +26,10 @@
     {
       "name": "Jupyter",
       "link": "{{ jupyter_link }}"
+    },
+    {
+      "name": "Flink",
+      "link": "{{ flink_link }}"
     }
   ],
   "frontend": {

--- a/salt/platform-testing/general.sls
+++ b/salt/platform-testing/general.sls
@@ -12,6 +12,7 @@
 {% set zookeeper_port = '2181' %}
 {% set dm_port = '5000' %}
 {% set opentsdb_port = '4242' %}
+{% set flink_history_server_port = '8082' %}
 
 {% set pnda_cluster = salt['pnda.cluster_name']() %}
 
@@ -40,6 +41,14 @@
 {%- if dm_nodes is not none and dm_nodes|length > 0 -%}
   {%- for ip in dm_nodes -%}
   {%- do dm_hosts.append("http://" + ip + ':' + dm_port) -%}
+  {%- endfor -%}
+{%- endif -%}
+
+{%- set fh_hosts = [] -%}
+{%- set fh_nodes = salt['pnda.get_hosts_for_role']('flink') -%}
+{%- if fh_nodes is not none and fh_nodes|length > 0 -%}
+  {%- for ip in fh_nodes -%}
+    {%- do fh_hosts.append("http://" + ip + ':' + flink_history_server_port) -%}
   {%- endfor -%}
 {%- endif -%}
 
@@ -233,6 +242,44 @@ platform-testing-general-crontab-dm-blackbox:
     - name: /sbin/start platform-testing-general-dm-blackbox
 {% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-general-dm-blackbox
+{% endif %}
+
+{% endif %}
+
+{%- if fh_hosts is not none and fh_hosts|length > 0 %}
+platform-testing-general-install-requirements-flink:
+  pip.installed:
+    - bin_env: {{ virtual_env_dir }}
+    - requirements: {{ platform_testing_directory }}/{{platform_testing_package}}-{{ platform_testing_version }}/plugins/flink/requirements.txt
+    - index_url: {{ pip_index_url }}
+    - require:
+      - virtualenv: platform-testing-general-create-venv
+
+platform-testing-general-flink_service:
+  file.managed:
+{% if grains['os'] == 'Ubuntu' %}
+    - source: salt://platform-testing/templates/platform-testing-general-flink.conf.tpl
+    - name: /etc/init/platform-testing-general-flink.conf
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - source: salt://platform-testing/templates/platform-testing-general-flink.service.tpl
+    - name: /usr/lib/systemd/system/platform-testing-general-flink.service
+{%- endif %}
+    - mode: 644
+    - template: jinja
+    - context:
+      platform_testing_directory: {{ platform_testing_directory }}
+      platform_testing_package: {{ platform_testing_package }}
+      console_hosts: {{ console_hosts }}
+      fh_hosts: {{ fh_hosts }}
+
+platform-testing-general-crontab-flink:
+  cron.present:
+    - identifier: PLATFORM-TESTING-FLINK
+    - user: root
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /sbin/start platform-testing-general-flink
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - name: /bin/systemctl start platform-testing-general-flink
 {% endif %}
 
 {% endif %}

--- a/salt/platform-testing/templates/platform-testing-general-flink.conf.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-flink.conf.tpl
@@ -1,0 +1,6 @@
+description "Platform testing general flink upstart script"
+author      "PNDA team"
+start on runlevel [2345]
+task
+env PYTHON_HOME={{ platform_testing_directory }}/{{platform_testing_package}}/venv
+exec ${PYTHON_HOME}/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin flink --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--fhendpoint {{ fh_hosts|join(',') }}"

--- a/salt/platform-testing/templates/platform-testing-general-flink.service.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-flink.service.tpl
@@ -1,0 +1,6 @@
+[Unit]
+Description=Platform testing general Flink
+
+[Service]
+Type=oneshot
+ExecStart={{ platform_testing_directory }}/{{platform_testing_package}}/venv/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin flink --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--fhendpoint {{ fh_hosts|join(',') }}"


### PR DESCRIPTION
# Problem Statement:
PNDA-4431: Add basic platform test & console elements for flink

Dependency PR:
- https://github.com/pndaproject/platform-salt/pull/462
- https://github.com/pndaproject/platform-testing/pull/60
- https://github.com/pndaproject/platform-console-frontend/pull/74

# Change:
- Added flink platform testing general service.
- Configured back-end to setup up appropriate link for pnda console element.

# Test details:
Verified the fix for AWS:
- UBUNTU - PICO -CDH & HDP
- UBUNTU - STD -CDH & HDP
- RHEL - PICO -CDH & HDP
- RHEL - STD -CDH & HDP
Verification Done for openstack.