### PR TITLE
PNDA-4432: Handle logging for flink

### DIFF
--- a/salt/flink/files/log4j-cli.properties
+++ b/salt/flink/files/log4j-cli.properties
@@ -1,0 +1,44 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, file
+
+# Log all infos in the given file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.file=${log.file}
+log4j.appender.file.append=true
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+log4j.appender.file.MaxFileSize=2MB
+log4j.appender.file.MaxBackupIndex=5
+
+# Log output from org.apache.flink.yarn to the console. This is used by the
+# CliFrontend class when using a per-job YARN cluster.
+log4j.logger.org.apache.flink.yarn=INFO, console
+log4j.logger.org.apache.flink.yarn.cli.FlinkYarnSessionCli=INFO, console
+log4j.logger.org.apache.hadoop=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# suppress the warning that hadoop native libraries are not loaded (irrelevant for the client)
+log4j.logger.org.apache.hadoop.util.NativeCodeLoader=OFF
+
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file

--- a/salt/flink/init.sls
+++ b/salt/flink/init.sls
@@ -81,6 +81,11 @@ flink-create_flink_logs_directory:
     - user: {{ pnda_user }}
     - makedirs: True
 
+flink-configure_log_properties:
+  file.managed:
+    - name: {{ flink_real_dir }}/conf/log4j-cli.properties
+    - source: salt://flink/files/log4j-cli.properties
+
 flink-jobmanager_archive_dir_initialize-hdfs:
   cmd.run:
     - name: 'sudo -u hdfs hdfs dfs -mkdir -p {{ archive_dir_hdfs_path }}; sudo -u hdfs hdfs dfs -chmod 777 {{ archive_dir_hdfs_path }}'

--- a/salt/logserver/logshipper_templates/shipper.conf.tpl
+++ b/salt/logserver/logshipper_templates/shipper.conf.tpl
@@ -122,10 +122,26 @@ input {
           }
    }
    file {
+          path => ["/var/log/pnda/flink/*.log"]
+          add_field => {"source" => "flink"}
+          sincedb_path => "{{ install_dir }}/logstash/sincedb/db"
+          codec => multiline {
+            pattern => "^%{TIMESTAMP_ISO8601}"
+            negate => true
+            what => "previous"
+          }
+   }
+   file {
           path => ["/var/log/pnda/hadoop-yarn/container/application_*/container_*/stdout",
                    "/var/log/pnda/hadoop-yarn/container/application_*/container_*/stderr",
                    "/var/log/pnda/hadoop-yarn/container/application_*/container_*/syslog",
-                   "/var/log/pnda/hadoop-yarn/container/application_*/container_*/spark.log"]
+                   "/var/log/pnda/hadoop-yarn/container/application_*/container_*/spark.log",
+                   "/var/log/pnda/hadoop-yarn/container/application_*/container_*/taskmanager.log",
+                   "/var/log/pnda/hadoop-yarn/container/application_*/container_*/taskmanager.out",
+                   "/var/log/pnda/hadoop-yarn/container/application_*/container_*/taskmanager.err",
+                   "/var/log/pnda/hadoop-yarn/container/application_*/container_*/jobmanager.log",
+                   "/var/log/pnda/hadoop-yarn/container/application_*/container_*/jobmanager.out",
+                   "/var/log/pnda/hadoop-yarn/container/application_*/container_*/jobmanager.err"]
           add_field => {"source" => "yarn"}
           sincedb_path => "{{ install_dir }}/logstash/sincedb/db"
           discover_interval => "5"


### PR DESCRIPTION
# Problem Statement:
PNDA-4432: Handle logging for Flink

# Analysis:
Flink application user should be able to find all the logs which flink generates for analysis purposes & debugging. The flink history server logs and application logs are aggregated by the PNDA logshipper to collect and ship logs in order to view on dashboard.

# Changes:
1. Provided state to copy template of log4j-cli with modified logging properties (log-rotation) for applications submitted with flink client. 
2. Updated shipper template to read flink logs generated for flink applications as well as for applications submitted to YARN.

# Test details:
Verified for AWS:

UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP