### PR TITLE
PNDA-4429: Support applications through pyflink

### DIFF
--- a/pillar/flavors/bmstandard.sls
+++ b/pillar/flavors/bmstandard.sls
@@ -40,7 +40,8 @@
             "taskmanager_heapsize": 2048,
             "taskmanager_slots": 1,
             "parallelism": 1,
-            "taskmanager_mem_preallocate": false
+            "taskmanager_mem_preallocate": false,
+            "pyflink_yarn_container_count": 1
         }
     }
 }

--- a/pillar/flavors/distribution.sls
+++ b/pillar/flavors/distribution.sls
@@ -31,7 +31,8 @@
             "taskmanager_heapsize": 2048,
             "taskmanager_slots": 1,
             "parallelism": 1,
-            "taskmanager_mem_preallocate": false
+            "taskmanager_mem_preallocate": false,
+            "pyflink_yarn_container_count": 1
         }
     }
 }

--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -43,7 +43,8 @@
             "taskmanager_heapsize": 1024,
             "taskmanager_slots": 1,
             "parallelism": 1,
-            "taskmanager_mem_preallocate": false
+            "taskmanager_mem_preallocate": false,
+            "pyflink_yarn_container_count": 1
         }
     }
 }

--- a/pillar/flavors/production.sls
+++ b/pillar/flavors/production.sls
@@ -43,7 +43,8 @@
             "taskmanager_heapsize": 2048,
             "taskmanager_slots": 1,
             "parallelism": 1,
-            "taskmanager_mem_preallocate": false
+            "taskmanager_mem_preallocate": false,
+            "pyflink_yarn_container_count": 1
         }
     }
 }

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -43,7 +43,8 @@
             "taskmanager_heapsize": 2048,
             "taskmanager_slots": 1,
             "parallelism": 1,
-            "taskmanager_mem_preallocate": false
+            "taskmanager_mem_preallocate": false,
+            "pyflink_yarn_container_count": 1
         }
     }
 }

--- a/salt/flink/init.sls
+++ b/salt/flink/init.sls
@@ -27,6 +27,9 @@
 {% set hadoop_home_bin = '/opt/cloudera/parcels/CDH/bin' %}
 {% endif %}
 
+{% set python_tmp_dir = pnda_user + '/flink/tmp' %}
+{% set python_tmp_dir_hdfs_path = namenode + '/' + python_tmp_dir %}
+
 flink-create_flink_version_directory:
   file.directory:
     - name: {{ flink_real_dir }}
@@ -59,6 +62,16 @@ flink-copy_configurations:
       taskmanager_slots: {{ flavor_cfg.taskmanager_slots }}
       parallelism: {{ flavor_cfg.parallelism }}
       taskmanager_mem_preallocate: {{ flavor_cfg.taskmanager_mem_preallocate }}
+      python_tmp_dir: {{ python_tmp_dir }}
+
+flink-copy_pyflink_yarn_driver_script:
+  file.managed:
+    - name: {{ flink_real_dir }}/bin/pyflink-yarn.sh
+    - source: salt://flink/templates/pyflink-yarn.sh.tpl
+    - mode: 755
+    - template: jinja
+    - context:
+      pyflink_yarn_container_count: {{ flavor_cfg.pyflink_yarn_container_count }}
 
 flink-configure_log_dir:
   file.directory:
@@ -89,6 +102,10 @@ flink-configure_log_properties:
 flink-jobmanager_archive_dir_initialize-hdfs:
   cmd.run:
     - name: 'sudo -u hdfs hdfs dfs -mkdir -p {{ archive_dir_hdfs_path }}; sudo -u hdfs hdfs dfs -chmod 777 {{ archive_dir_hdfs_path }}'
+
+flink-python_dc_tmp_dir_initialize-hdfs:
+  cmd.run:
+    - name: 'sudo -u hdfs hdfs dfs -mkdir -p {{ python_tmp_dir_hdfs_path }}; sudo -u hdfs hdfs dfs -chmod 777 {{ python_tmp_dir_hdfs_path }}'
 
 flink-copy_service:
   file.managed:

--- a/salt/flink/templates/flink.conf.tpl
+++ b/salt/flink/templates/flink.conf.tpl
@@ -228,3 +228,4 @@ historyserver.archive.fs.refresh-interval: 10000
 
 # Configure log directory path for PNDA flink
 env.log.dir: /var/log/pnda/flink
+python.dc.tmp.dir: {{ namenode }}/{{ python_tmp_dir }}/dc

--- a/salt/flink/templates/pyflink-yarn.sh.tpl
+++ b/salt/flink/templates/pyflink-yarn.sh.tpl
@@ -1,0 +1,25 @@
+#!/bin/bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+. "$bin"/config.sh
+
+"$FLINK_BIN_DIR"/flink run -m yarn-cluster -yn {{pyflink_yarn_container_count}} -v "$FLINK_ROOT_DIR"/lib/flink-python*.jar "$@"


### PR DESCRIPTION
# Problem Statement:
PNDA-4429: Support applications through pyflink

# Analysis:
User should be able to execute the sample/example python application on the pnda cluster using yarn. 
Currently, python.dc.tmp.dir - configures the path where the python library, plan file and additional files will be uploaded, is not configured by default.

# Changes:
Configured the python.dc.tmp.dir to the valid hdfs path.

# Test details:
Verified for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP

**Note:** The example python applications in packaged flink are configured to execute on local cluster (the last line if file - local=True). To make them work for the yarn cluster, need to change the last line i.e. local=False.