### PR TITLE
PNDA-4483: Data management & cluster housekeeping

### DIFF
--- a/salt/hdfs-cleaner/init.sls
+++ b/salt/hdfs-cleaner/init.sls
@@ -10,6 +10,7 @@
 {% set hadoop_distro = grains['hadoop.distro'] %}
 {% set pnda_user  = pillar['pnda']['user'] %}
 {% set gobblin_work_dir = '/user/' + pnda_user + '/gobblin/work' %}
+{% set flink_job_dir = '/' + pnda_user + '/flink/completed-jobs' %}
 
 {% set install_dir = pillar['pnda']['homedir'] %}
 
@@ -17,10 +18,10 @@
 {% set pip_index_url = pillar['pip']['index_url'] %}
 
 {% if grains['hadoop.distro'] == 'HDP' %}
-{% set streaming_dirs_to_clean = '"/user/*/.sparkStaging/", "/app-logs/*/logs/", "/spark-history/"' %}
+{% set streaming_dirs_to_clean = '"/user/*/.sparkStaging/", "/app-logs/*/logs/", "/spark-history/", "/user/*/.flink/"' %}
 {% set general_dirs_to_clean = '"/mr-history/done/"' %}
 {% else %}
-{% set streaming_dirs_to_clean = '"/user/*/.sparkStaging/", "/tmp/logs/*/logs/", "/user/spark/applicationHistory/"' %}
+{% set streaming_dirs_to_clean = '"/user/*/.sparkStaging/", "/tmp/logs/*/logs/", "/user/spark/applicationHistory/", "/user/*/.flink/"' %}
 {% set general_dirs_to_clean = '"/user/history/done/"' %}
 {% endif %}
 
@@ -65,6 +66,7 @@ hdfs-cleaner-copy_config:
         archive_type: '{{ archive_type }}'
         archive_service: '{{ archive_service }}'
         gobblin_work_dir: {{ gobblin_work_dir }}
+        flink_job_dir: {{ flink_job_dir }}
         streaming_dirs_to_clean: '{{ streaming_dirs_to_clean }}'
         general_dirs_to_clean: '{{ general_dirs_to_clean }}'
     - require:

--- a/salt/hdfs-cleaner/templates/properties.json.tpl
+++ b/salt/hdfs-cleaner/templates/properties.json.tpl
@@ -16,7 +16,8 @@
     "general_dirs_to_clean": [{{ general_dirs_to_clean }}],
     "old_dirs_to_clean": [
         {"name": "{{ gobblin_work_dir }}/metrics", "age_seconds": 172800},
-        {"name": "{{ gobblin_work_dir }}/state-store/PullFromKafkaMR", "age_seconds": 172800}
+        {"name": "{{ gobblin_work_dir }}/state-store/PullFromKafkaMR", "age_seconds": 172800},
+        {"name": "{{ flink_job_dir }}", "age_seconds": 172800}
     ],
     "swift_repo": "{{ archive_type }}://{{ container }}{{ archive_service }}/{{ repo_path }}",
     "container_name": "{{ container }}",


### PR DESCRIPTION
# Problem Statement:
PNDA-4483: Data management & cluster housekeeping

# Analysis:
The logging data should be cleaned up regularly.

# Changes:
Considered cleaning up the below data -
- History server completed Jobs - Cleaned up based on age. And jobs older than 48 hours are cleaned up from HDFS.
- Streaming data - Similar to the spark cleanup the application data is cleanup for finished, killed and failed application ( i.e. only running application's data is not cleaned up)
- history server log data in local file-system - Changes done in logging PR to roll the logs in the /var/log/pnda/flink directory.  

# Test details:
Verified for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
