### PR TITLE
PNDA-4461: Deployment Manager - deploy Flink applications

### DIFF
--- a/salt/deployment-manager/templates/dm-config.json.tpl
+++ b/salt/deployment-manager/templates/dm-config.json.tpl
@@ -48,6 +48,7 @@
 {% set app_packages_hdfs_path = pillar['pnda']['app_packages']['app_packages_hdfs_path'] -%}
 
 {% set policy_file_link = pillar['resource_manager']['path'] + pillar['resource_manager']['policy_file'] %}
+{%- set flink_lib_dir = pillar['pnda']['homedir'] + '/flink/lib' -%}
 
 {
     "environment": {
@@ -66,7 +67,8 @@
         "jupyter_host": "{{ jupyter_host }}",
         "jupyter_notebook_directory": "jupyter_notebooks",
         "app_packages_hdfs_path":"{{ app_packages_hdfs_path }}",
-        "queue_policy": "{{ policy_file_link }}"
+        "queue_policy": "{{ policy_file_link }}",
+        "flink_lib_dir": "{{ flink_lib_dir }}"
     },
     "config": {
         "stage_root": "stage",

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -108,19 +108,19 @@ orchestrate-pnda-create_master_dataset:
     - timeout: 120
     - queue: True
 
-orchestrate-pnda-install_spark_wrapper:
-  salt.state:
-    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and ( G@hadoop:* or G@roles:jupyter )'
-    - tgt_type: compound
-    - sls: resource-manager
-    - timeout: 120
-    - queue: True
-
 orchestrate-pnda-install_flink:
   salt.state:
     - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@roles:flink'
     - tgt_type: compound
     - sls: flink
+    - timeout: 120
+    - queue: True
+
+orchestrate-pnda-install_spark_wrapper:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and ( G@hadoop:* or G@roles:jupyter )'
+    - tgt_type: compound
+    - sls: resource-manager
     - timeout: 120
     - queue: True
 


### PR DESCRIPTION
Problem Statement:
Deployment Manager - Packaging and deploying basic Flink applications 
in similar way to Spark for streaming & batch processing jobs.

Prerequisites:
PNDA-4429 story needs to merged before this PR.

Test details:
Verified changes on AWS setups:
UBUNTU - PICO -CDH & HDP
RHEL - PICO -CDH & HDP

Note:  Currently, log4j.properties file passing by user is not supported. Analysis is in progress, may need flink community support. 