### PR TITLE
PNDA-4045: Logstash multiline plugin not working properly.

### DIFF
--- a/salt/logserver/logshipper_templates/shipper.conf.tpl
+++ b/salt/logserver/logshipper_templates/shipper.conf.tpl
@@ -145,6 +145,11 @@ input {
           add_field => {"source" => "yarn"}
           sincedb_path => "{{ install_dir }}/logstash/sincedb/db"
           discover_interval => "5"
+          codec => multiline {
+            pattern => "^%{TIMESTAMP_ISO8601}"
+            negate => true
+            what => "previous"
+          }
    }
 
    {% for log_section in pillar['log-shipper-patterns'] %}


### PR DESCRIPTION
# Problem Statement:
PNDA-4045: Logstash multiline plugin not working properly.

# Analysis:
Logstash multiline plugin not working properly for yarn application logs. Version of logstash multiline plugin prior to ELK upgrade was logstash-codec-multiline (3.0.3). Current version in upgraded logstash is logstash-codec-multiline (3.0.9). The upgraded version of multiline plugin has some fixes related to issues that caused failures with multiline codec. Re-enabling multiline plugin is able to capture any exceptions occuring in yarn application logs as a single event.

# Changes:
Added multiline codec plugin for yarn application logs in shipper template.

# Test details
Submitted a job to yarn and caused failure in job execution in order to capture exceptions in yarn logs and verified it as a single event on dashboard.

RHEL - STD - HDP
UBUNTU - PICO -CDH & HDP