### PR TITLE
PNDA-4513: Flink Metrics - Configure Graphite Metrics reporter

### DIFF
--- a/salt/flink/templates/flink.conf.tpl
+++ b/salt/flink/templates/flink.conf.tpl
@@ -229,3 +229,10 @@ historyserver.archive.fs.refresh-interval: 10000
 # Configure log directory path for PNDA flink
 env.log.dir: /var/log/pnda/flink
 python.dc.tmp.dir: {{ namenode }}/{{ python_tmp_dir }}/dc
+# Expose Metric to an external system (Graphite) by configuring the Reporter
+metrics.reporters: grph
+metrics.reporter.grph.class: org.apache.flink.metrics.graphite.GraphiteReporter
+metrics.reporter.grph.host: {{ graphite_node }}
+metrics.reporter.grph.port: {{ graphite_port }}
+metrics.reporter.grph.protocol: TCP
+metrics.reporter.grph.prefix: flink

--- a/salt/graphite-api/files/whitelist.conf
+++ b/salt/graphite-api/files/whitelist.conf
@@ -102,3 +102,4 @@ driver\.DAGScheduler\.job\.allJobs
 ^hadoop*
 ^application*
 ^carbon*
+^flink*


### PR DESCRIPTION
# Problem Statement:
PNDA-4513: Flink Metrics - Configure Graphite Metrics reporter

# Changes:
Below configurations are required -
- Update flink file ( .yaml ) for configuring graphite as reporter for monitoring data. 
- Copy dependency jars ( for graphite ) from packaged opt to the flink lib.
- Configure graphite whitelist for reading flink monitor logs.

# Test details:
Verified for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP