### PR TITLE
Swap out heredoc for pipe expression

### DIFF
--- a/salt/volumes/init.sls
+++ b/salt/volumes/init.sls
@@ -75,8 +75,7 @@
     volumes-format-{{ device }}:
       cmd.run:
         - name: mkfs -t {{ fs_type  }} {{ mkfs_opts }} {{ device }}
-        - unless:
-          - 'grep "{{ device }}" <<< "$(cat /etc/fstab)"'
+        - unless: cat /etc/fstab | grep "{{ device }}"
 
     volumes-mount-{{ device }}:
       mount.mounted:


### PR DESCRIPTION
SaltStack 'unless' clause appears to have some platform specific behaviour when using constructs such as pipes. Specifically, here the result of grepping the heredoc fails on Ubuntu.

This was preventing upgrades from release/4.0 to current develop.

PNDA-4514