### PR TITLE
PNDA-4510: Logrotate not working for /var/log/pnda

### DIFF
--- a/salt/logserver/logserver_files/logrotate.conf
+++ b/salt/logserver/logserver_files/logrotate.conf
@@ -1,4 +1,5 @@
 /var/log/pnda/*.log {
+    su root root
     daily
     compress
     size 10M
@@ -6,6 +7,7 @@
     copytruncate
 }
 /var/log/pnda/*/*.log {
+    su root root
     daily
     compress
     size 10M


### PR DESCRIPTION
# Problem Statement:
PNDA-4510: Logrotate not working for /var/log/pnda

# Analysis:
Logrotate is not functioning as expected for rotating logs in /var/log/pnda. On manual execution prompts error for insecure permissions. To fix this error added su directive to the configurations in order to specify the user/group to be used for log rotation. 

# Changes:
Modified salt script to copy logrotate.conf as a template to which the group name is passed as a variable. The variable is added to pillar which is read in the salt script and based on OS corresponding group name is passed to logrotate.conf file.

# Test details
RHEL - STD - HDP
RHEL - PICO - CDH & HDP