### PR TITLE
PNDA-4532 : Add Application log into logshipper and integrate logrotate

### DIFF
--- a/salt/logserver/logserver.sls
+++ b/salt/logserver/logserver.sls
@@ -68,6 +68,20 @@ logserver-add_crontab_entry2:
     - user: root
     - minute: 15
 
+logserver-add_crontab_entry3:
+  cron.present:
+    - identifier: DELETE-PLATFORM-APP-OLD
+    - name: /usr/bin/find /var/log/pnda -name 'platform_app*' -type f -mmin +4320 -delete
+    - user: root
+    - minute: 15
+
+logserver-add_crontab_entry4:
+  cron.present:
+    - identifier: DELETE-PLATFORM-APP-ZERO
+    - name: /usr/bin/find /var/log/pnda -name 'platform_app*' -type f -size 0 -delete
+    - user: root
+    - minute: 15
+
 logserver-create_log_folder:
   file.directory:
     - name: /var/log/pnda

--- a/salt/logserver/logshipper_templates/shipper.conf.tpl
+++ b/salt/logserver/logshipper_templates/shipper.conf.tpl
@@ -133,6 +133,16 @@ filter {
        else if [_systemd_unit] == "jupyterhub.service" {
            mutate {add_field => {"source" => "jupyterhub"}}
        }
+       else if [_systemd_unit] =~ "^platform_app" {
+           mutate {
+             add_field => {"source" => "%{_systemd_unit}"}
+           }
+           mutate {
+             gsub => [
+               "source", ".service", ""
+             ]
+           }
+       }
        else {
            drop { }
        }


### PR DESCRIPTION
Analysis
Currently, only YARN application logs are shipping to log server, but not the pnda application journalctl logs.

Solution
Added logshipper config to add logs from pnda application supervisors (systemd / journalctl) into log shipper.
Added crontab entries to delete pnda application journalctl logs older than 3 days without modification

Files Modified
salt/logserver/logserver.sls
salt/logserver/logshipper_templates/shipper.conf.tpl

Tested in RHEL HDP
