### PR TITLE
PNDA-4535:Modify DNS search domain order in /etc/resolve.conf

### DIFF
--- a/salt/consul/dns.sls
+++ b/salt/consul/dns.sls
@@ -12,7 +12,7 @@ consul_dns-add-domain:
   file.replace:
     - name: /etc/resolv.conf
     - pattern: 'search(.*)'
-    - repl: 'search\1 {{ domain_name }}'
+    - repl: 'search {{ domain_name }} \1'
 
 {% for cfg_file in salt['cmd.shell']('ls -1 /etc/sysconfig/network-scripts/ifcfg-*').split('\n') %}
 consul_turn-off-peer-dns-{{ cfg_file }}:


### PR DESCRIPTION
Modified the order for DNS search domain
PNDA domain as first in search domain


Tested in AWS and OpenStack HDP flavor 

