### PR TITLE
PNDA-4100: Test Master Dataset Health

### DIFF
--- a/salt/gobblin/init.sls
+++ b/salt/gobblin/init.sls
@@ -184,15 +184,6 @@ gobblin-systemctl_reload:
   cmd.run:
     - name: /bin/systemctl daemon-reload
 
-gobblin-add_gobblin_crontab_entry:
-  cron.present:
-    - identifier: GOBBLIN
-    - name: /bin/systemctl start gobblin
-    - user: root
-    - minute: 0,30
-    - require:
-      - file: gobblin-install_gobblin_service_script
-
 {% if perform_compaction %}
 gobblin-add_gobblin_compact_crontab_entry:
   cron.present:

--- a/salt/gobblin/initial_gobblin_run.sls
+++ b/salt/gobblin/initial_gobblin_run.sls
@@ -1,0 +1,18 @@
+gobblin-require_gobblin_service_script:
+  file.exists:
+    - name: /usr/lib/systemd/system/gobblin.service
+
+gobblin-systemctl_redhat_start:
+  cmd.run:
+    - name: /bin/systemctl start gobblin
+    - require:
+      - file: gobblin-require_gobblin_service_script 
+
+gobblin-add_gobblin_crontab_entry:
+  cron.present:
+    - identifier: GOBBLIN
+    - name: /bin/systemctl start gobblin
+    - user: root
+    - minute: 0,30
+    - require:
+      - file: gobblin-require_gobblin_service_script

--- a/salt/gobblin/templates/mr.pull.tpl
+++ b/salt/gobblin/templates/mr.pull.tpl
@@ -50,4 +50,4 @@ metrics.reporting.file.enabled=true
 # want to ingest
 # Don't ingest the avro.internal.testbot topic as it's only an internal PNDA
 # testing topic
-topic.blacklist=__consumer_offsets,avro.internal.testbot
+topic.blacklist=__consumer_offsets

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -269,3 +269,11 @@ orchestrate-pnda-install_remove_new_node_markers:
     - sls: orchestrate.remove_new_node_marker
     - timeout: 120
     - queue: True
+
+orchestrate-pnda-initial_gobblin_run:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@roles:gobblin'
+    - tgt_type: compound
+    - sls: gobblin.initial_gobblin_run
+    - timeout: 120
+    - queue: True

--- a/salt/platform-testing/templates/platform-testing-general-dataset.service.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-dataset.service.tpl
@@ -1,0 +1,6 @@
+[Unit]
+Description=Platform testing general dataset
+
+[Service]
+Type=oneshot
+ExecStart={{ platform_testing_directory }}/{{platform_testing_package}}/venv/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin dataset --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--data_service {{ data_service_hosts|join(',') }} --cluster_name {{ pnda_cluster }} --cron_interval {{ gobblin_cron_interval }} --metric_console {{ metric_console_hosts|join(',') }} --num_attempts {{ gobblin_retry_count }} --master_dataset_dir {{ pnda_master_dataset_location }} --quarantine_dir {{ pnda_quarantine_dataset_location }} --console_user {{ console_user }} --console_password {{ console_password }}"


### PR DESCRIPTION
# Problem Statement:
PNDA-4100: Test Master Dataset Health

# Analysis:
1.  Run Gobblin service manually(Before CRON Job run) to test Gobblin health initially
2.  Add CRON tab entry for Gobblin after initial Gobblin run
3.  Remove KAFKA internal test topic from blacklist in Gobblin configuration file
4.  Create service file and add CRON tab entry to run plugin(dataset) in platform-testing to test Master 
     Dataset Health

# Approach:
1. Add state file inside Gobblin directory to run Gobblin service manually
2. Add CRON tab entry for Gobblin after executing Gobblin service initially to avoid simultaneous runs
3. In order to test Dataset creation remove KAFKA internal test topic from Gobblin's blacklist
4. Add additional steps in platform-testing state to create service file and schedule CRON job to run 
    dataset plugin

# Test details:
UBUNTU-PICO-CDH
UBUNTU-STD-CDH
UBUNTU-PICO-HDP
UBUNTU-STD-HDP
RHEL-PICO-CDH
RHEL-STD-CDH
RHEL-PICO-HDP
RHEL-STD-HDP