### PR TITLE
PNDA-4517: Oozie ssh action support for flink batch jobs

### DIFF
--- a/salt/deployment-manager/generate_keys.sls
+++ b/salt/deployment-manager/generate_keys.sls
@@ -10,10 +10,10 @@ deployment-manager-gen_key:
     - name: 'ssh-keygen -b 2048 -t rsa -f {{ keys_directory }}/dm.pem -q -N ""'
     - unless: test -f {{ keys_directory }}/dm.pem
 
-deployment-manager-push_key:
+deployment-manager-push_keys:
   module.run:
-    - name: cp.push
-    - path: '{{ keys_directory }}/dm.pem.pub'
-    - upload_path: '/keys/dm.pem.pub'
+    - name: cp.push_dir
+    - path: '{{ keys_directory }}/'
+    - upload_path: '/keys/'
     - require:
       - cmd: deployment-manager-gen_key

--- a/salt/deployment-manager/templates/dm-config.json.tpl
+++ b/salt/deployment-manager/templates/dm-config.json.tpl
@@ -51,7 +51,8 @@
 {%- set flink_lib_dir = pillar['pnda']['homedir'] + '/flink/lib' -%}
 {%- set flink_history_server_port = salt['pillar.get']('flink:history_server_port', 8082) -%}
 {%- set fh_nodes = salt['pnda.get_hosts_for_role']('flink') -%}
-{%- set flink_history_server = fh_nodes[0]+':'+flink_history_server_port|string -%}
+{%- set flink_host = fh_nodes[0] -%}
+{%- set flink_history_server = flink_host+':'+flink_history_server_port|string -%}
 
 {% set resource_manager_path = pillar['resource_manager']['path'] %}
 
@@ -78,6 +79,7 @@
         "flink_lib_dir": "{{ flink_lib_dir }}",
         "flink_history_server": "{{ flink_history_server }}",
         "spark_submit": "{{ resource_manager_path }}/bin/spark-submit",
+        "flink_host" : "{{ flink_host }}",
         "flink": "{{ resource_manager_path }}/bin/flink"
     },
     "config": {

--- a/salt/oozie_ssh_auth/init.sls
+++ b/salt/oozie_ssh_auth/init.sls
@@ -1,0 +1,20 @@
+{% set oozie_dir = salt['cmd.run']('getent passwd oozie | cut -d: -f6') %}
+{% set oozie_ssh_dir = oozie_dir+"/.ssh" %}
+
+{% set dm_id = salt['pnda.get_hosts_for_role']('deployment_manager')[0] %}
+
+oozie-ssh-create-dir:
+  file.directory:
+    - name: {{ oozie_ssh_dir }}
+    - makedirs: True
+    - user: oozie
+    - group: hadoop
+    - mode: 700
+
+oozie-ssh-install-key:
+  file.managed:
+    - name: {{ oozie_ssh_dir }}/id_rsa
+    - source: salt://{{ dm_id }}/keys/dm.pem
+    - user: oozie
+    - group: hadoop
+    - mode: 600

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -270,6 +270,14 @@ orchestrate-pnda-app-packages-hdfs:
     - timeout: 120
     - queue: True
 
+orchestrate-pnda-oozie-ssh-install-keys:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@roles:oozie_server'
+    - tgt_type: compound
+    - sls: oozie_ssh_auth
+    - timeout: 120
+    - queue: True
+
 orchestrate-pnda-knox:
   salt.state:
     - tgt: 'G@pnda_cluster:{{pnda_cluster}} and ( G@roles:knox )'


### PR DESCRIPTION
### Problem Statement:
OOZIE does not natively support an action for submitting Flink job on yarn-cluster.  Need to use SSH action for executing the flink batch job in PNDA

### Changes Done:
- OOZIE SSH action requires passwordless ssh connection between oozie server and target host
- Generated key pairs in oozie server using oozie user
- Copied public key file to deployment manager host

### Test Details:
AWS-RHEL-HDP-PICO-STD
OpenStack-RHEL-HDP-PICO

Dependency PR:
https://github.com/pndaproject/platform-deployment-manager/pull/78