### PR TITLE
PNDA-4544: Upgrade Flink from 1.4 to 1.4.2 in PNDA

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -49,7 +49,7 @@ gobblin:
   release_version: 0.11.0
 
 flink:
-  release_version: 1.4.0
+  release_version: 1.4.2
   historyserver_web_port: 8082
   jobmanager_web_port: 8083
 


### PR DESCRIPTION
# Problem Statement:
PNDA-4544: Upgrade Flink from 1.4 to 1.4.2 in PNDA

# Changes:
Upgraded flink version from 1.4.0 to 1.4.2 in pillar/service.sls.

# Test details
RHEL - PICO - CDH & HDP
RHEL - STD - HDP