### PR TITLE
PNDA-4075: Number of data volumes to be configurable in pnda_env.yaml…

### DIFF
--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -15,12 +15,10 @@
             "kafka_heapsize": 2147483648
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_pico.py",
-            "data_volumes_count": 1
+            "template_file": "cfg_pico.py"
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_pico.py",
-            "data_volumes_count": 1
+            "template_file": "cfg_pico.py"
         },
         "curator": {
             "days_to_keep": 1

--- a/pillar/flavors/production.sls
+++ b/pillar/flavors/production.sls
@@ -10,12 +10,10 @@
             "max_mappers": 20
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_production.py",
-            "data_volumes_count": 24
+            "template_file": "cfg_production.py"
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_production.py",
-            "data_volumes_count": 24
+            "template_file": "cfg_production.py"
         },
         "curator": {
             "days_to_keep": 6

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -15,12 +15,10 @@
             "kafka_heapsize": 4294967296
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_standard.py",
-            "data_volumes_count": 1
+            "template_file": "cfg_standard.py"
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_standard.py",
-            "data_volumes_count": 1
+            "template_file": "cfg_standard.py"
         },
         "curator": {
             "days_to_keep": 6

--- a/salt/cdh/setup_hadoop.sls
+++ b/salt/cdh/setup_hadoop.sls
@@ -1,5 +1,5 @@
 {% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
-
+{% set data_volumes = pillar['datanode']['data_volumes'] %}
 {% set scripts_location = '/tmp/pnda-install/' + sls %}
 {% set pnda_cluster = salt['pnda.cluster_name']() %}
 {% set cloudera_cdh_repo = pillar['cloudera']['parcel_repo'] %}
@@ -17,17 +17,6 @@
 {% set pnda_home = pillar['pnda']['homedir'] %}
 {% set app_packages_dir = pnda_home + "/app-packages" %}
 {% set pnda_graphite_host = salt['pnda.get_hosts_for_role']('graphite')[0] %}
-
-{%- set data_volume_list = [] %}
-{%- for n in range(flavor_cfg.data_volumes_count) -%}
-  {%- if flavor_cfg.data_volumes_count > 10 and n < 10 -%}
-    {%- set prefix = '/data0' -%}
-  {%- else -%}
-    {%- set prefix = '/data' -%}
-  {%- endif -%}
-  {%- do data_volume_list.append(prefix ~ n ~ '/dn') %}
-{%- endfor -%}
-{%- set data_volumes = data_volume_list|join(",") %}
 
 include:
   - python-pip

--- a/salt/hdp/setup_hadoop.sls
+++ b/salt/hdp/setup_hadoop.sls
@@ -1,5 +1,5 @@
 {% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
-
+{% set data_volumes = pillar['datanode']['data_volumes'] %}
 {% set pnda_home = pillar['pnda']['homedir'] %}
 {% set app_packages_dir = pnda_home + "/app-packages" %}
 
@@ -19,17 +19,6 @@
 {% set pnda_user = pillar['pnda']['user'] %}
 
 {% set pip_index_url = pillar['pip']['index_url'] %}
-
-{%- set data_volume_list = [] %}
-{%- for n in range(flavor_cfg.data_volumes_count) -%}
-  {%- if flavor_cfg.data_volumes_count > 10 and n < 10 -%}
-    {%- set prefix = '/data0' -%}
-  {%- else -%}
-    {%- set prefix = '/data' -%}
-  {%- endif -%}
-  {%- do data_volume_list.append(prefix ~ n ~ '/dn') %}
-{%- endfor -%}
-{%- set data_volumes = data_volume_list|join(",") %}
 
 include:
   - python-pip


### PR DESCRIPTION
… to allow multiple data drives to be used

Analysis
Number of data volumes should be configurable in pnda_env.yaml to allow multiple data drives to be used.

Solution
Removed data volumes generation snippet from setup_hadoop.sls.

Files Modified
salt/cdh/setup_hadoop.sls
salt/hdp/setup_hadoop.sls

Tested in  RHEL HDP, RHEL CDH