### PR TITLE
PNDA-4536 : Kafka data dirs to be configurable in pnda_env.yaml

### DIFF
--- a/pillar/flavors/bmstandard.sls
+++ b/pillar/flavors/bmstandard.sls
@@ -26,7 +26,6 @@
             "zookeeper_data_dir": "/var/lib/zookeeper"
         },
         "kafka.server": {
-            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824
         },
         "mysql": {

--- a/pillar/flavors/distribution.sls
+++ b/pillar/flavors/distribution.sls
@@ -17,7 +17,6 @@
             "zookeeper_data_dir": "/var/lib/zookeeper"
         },
         "kafka.server": {
-            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824
         },
         "mysql": {

--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -15,12 +15,10 @@
             "kafka_heapsize": 2147483648
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_pico.py",
-            "data_volumes_count": 1
+            "template_file": "cfg_pico.py"
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_pico.py",
-            "data_volumes_count": 1
+            "template_file": "cfg_pico.py"
         },
         "curator": {
             "days_to_keep": 1

--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -10,7 +10,6 @@
             "max_mappers": 5
         },
         "kafka.server": {
-            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 314572800,
             "kafka_heapsize": 2147483648
         },

--- a/pillar/flavors/production.sls
+++ b/pillar/flavors/production.sls
@@ -19,7 +19,6 @@
             "days_to_keep": 6
         },
         "kafka.server": {
-            "data_dirs": ["/mnt/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824,
             "kafka_heapsize": 17179869184
         },

--- a/pillar/flavors/production.sls
+++ b/pillar/flavors/production.sls
@@ -10,12 +10,10 @@
             "max_mappers": 20
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_production.py",
-            "data_volumes_count": 24
+            "template_file": "cfg_production.py"
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_production.py",
-            "data_volumes_count": 24
+            "template_file": "cfg_production.py"
         },
         "curator": {
             "days_to_keep": 6

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -10,7 +10,6 @@
             "max_mappers": 50
         },
         "kafka.server": {
-            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824,
             "kafka_heapsize": 4294967296
         },

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -15,12 +15,10 @@
             "kafka_heapsize": 4294967296
         },
         "cdh.setup_hadoop": {
-            "template_file": "cfg_standard.py",
-            "data_volumes_count": 1
+            "template_file": "cfg_standard.py"
         },
         "hdp.setup_hadoop": {
-            "template_file": "cfg_standard.py",
-            "data_volumes_count": 1
+            "template_file": "cfg_standard.py"
         },
         "curator": {
             "days_to_keep": 6

--- a/salt/cdh/setup_hadoop.sls
+++ b/salt/cdh/setup_hadoop.sls
@@ -1,5 +1,5 @@
 {% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
-
+{% set data_volumes = pillar['datanode']['data_volumes'] %}
 {% set scripts_location = '/tmp/pnda-install/' + sls %}
 {% set pnda_cluster = salt['pnda.cluster_name']() %}
 {% set cloudera_cdh_repo = pillar['cloudera']['parcel_repo'] %}
@@ -17,17 +17,6 @@
 {% set pnda_home = pillar['pnda']['homedir'] %}
 {% set app_packages_dir = pnda_home + "/app-packages" %}
 {% set pnda_graphite_host = salt['pnda.get_hosts_for_role']('graphite')[0] %}
-
-{%- set data_volume_list = [] %}
-{%- for n in range(flavor_cfg.data_volumes_count) -%}
-  {%- if flavor_cfg.data_volumes_count > 10 and n < 10 -%}
-    {%- set prefix = '/data0' -%}
-  {%- else -%}
-    {%- set prefix = '/data' -%}
-  {%- endif -%}
-  {%- do data_volume_list.append(prefix ~ n ~ '/dn') %}
-{%- endfor -%}
-{%- set data_volumes = data_volume_list|join(",") %}
 
 include:
   - python-pip

--- a/salt/hdp/setup_hadoop.sls
+++ b/salt/hdp/setup_hadoop.sls
@@ -1,5 +1,5 @@
 {% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
-
+{% set data_volumes = pillar['datanode']['data_volumes'] %}
 {% set pnda_home = pillar['pnda']['homedir'] %}
 {% set app_packages_dir = pnda_home + "/app-packages" %}
 
@@ -19,17 +19,6 @@
 {% set pnda_user = pillar['pnda']['user'] %}
 
 {% set pip_index_url = pillar['pip']['index_url'] %}
-
-{%- set data_volume_list = [] %}
-{%- for n in range(flavor_cfg.data_volumes_count) -%}
-  {%- if flavor_cfg.data_volumes_count > 10 and n < 10 -%}
-    {%- set prefix = '/data0' -%}
-  {%- else -%}
-    {%- set prefix = '/data' -%}
-  {%- endif -%}
-  {%- do data_volume_list.append(prefix ~ n ~ '/dn') %}
-{%- endfor -%}
-{%- set data_volumes = data_volume_list|join(",") %}
 
 include:
   - python-pip

--- a/salt/kafka-tool/init.sls
+++ b/salt/kafka-tool/init.sls
@@ -1,5 +1,6 @@
 #read all pillar data
-{% set flavor_cfg = pillar['pnda_flavor']['states']['kafka.server'] %}
+{% set data_dirs = pillar['kafka']['data_dirs'] %}
+{% set data_dirs_list = data_dirs.split(',') %}
 
 {% set install_dir = pillar['pnda']['homedir'] %}
 {% set packages_server = pillar['packages_server']['base_uri'] %}
@@ -9,7 +10,7 @@
 
 {% set p  = salt['pillar.get']('kafka', {}) %}
 {% set local_kafka_path = p.get('prefix', '/opt/pnda/kafka') %}
-{% set kafka_log_path = flavor_cfg.data_dirs[0] %}
+{% set kafka_log_path = data_dirs_list[0] %}
 
 {%- set zk_ips = [] -%}
 {%- for ip in salt['pnda.kafka_zookeepers_hosts']() -%}

--- a/salt/kafka/server.sls
+++ b/salt/kafka/server.sls
@@ -37,9 +37,9 @@ kafka-directories:
       - user
       - group
     - names:
-{% for log_dir in config.log_dirs %}
+{%- for log_dir in config.log_dirs %}
       - {{ log_dir }}
-{% endfor %}
+{%- endfor %}
 
 kafka-server-conf:
   file.managed:

--- a/salt/kafka/settings.sls
+++ b/salt/kafka/settings.sls
@@ -2,7 +2,8 @@
 {% set pc = p.get('config', {}) %}
 {% set g  = salt['grains.get']('kafka', {}) %}
 {% set gc = g.get('config', {}) %}
-{% set flavor_cfg = pillar['pnda_flavor']['states']['kafka.server'] %}
+{% set data_dirs = pillar['kafka']['data_dirs'] %}
+{% set data_dirs_list = data_dirs.split(',') %}
 
 # these are global - hence pillar-only
 {%- set prefix            = p.get('prefix', '/opt/pnda/kafka') %}
@@ -22,7 +23,7 @@
   'broker_id': gc.get('broker_id', pc.get('broker_id', 0)),
   'port': gc.get('port', pc.get('port', 9092)),
   'zookeeper_connect': gc.get('zookeeper_connect', pc.get('zookeeper_connect', 'localhost:2181')),
-  'log_dirs': flavor_cfg.data_dirs,
+  'log_dirs': data_dirs_list,
   'num_partitions': gc.get('num_partitions', pc.get('num_partitions', 2)),
   'log_retention_bytes': gc.get('log_retention_bytes', pc.get('log_retention_bytes', 16106127360)),
   'host_name': gc.get('host_name', pc.host_name),


### PR DESCRIPTION
Analysis
Currently, the Kafka volumes hardcoded in the flavor cfg sls. Number of Kafka volumes should be configurable in pnda_env.yaml to allow multiple Kafka drives to be used

Solution
Removed Kafka directory from flavor cfg sls
Passed the pillar value, which was exported in PNDA CLI to Kafka log dirs

Files Modified
pillar/flavors/bmstandard.sls
pillar/flavors/distribution.sls
pillar/flavors/pico.sls
pillar/flavors/production.sls
pillar/flavors/standard.sls
salt/kafka-tool/init.sls
salt/kafka/server.sls
salt/kafka/settings.sls

Tested in RHEL HDP, RHEL CDH