### PR TITLE
PNDA-4222: Link for all tsdb nodes

### DIFF
--- a/salt/console-frontend/templates/PNDA.json.tpl
+++ b/salt/console-frontend/templates/PNDA.json.tpl
@@ -13,7 +13,7 @@
     },
     {
       "name": "OpenTSDB",
-      "link": "{{ opentsdb_link }}"
+      "link": "{{ opentsdb_hosts }}"
     },
     {
       "name": "Grafana",


### PR DESCRIPTION
### Problem statement:
PNDA dashboard's OpenTSDB cog leads to only first node's dashboard even in case of cluster having multiple tsdb nodes.
### Changes done:
- Generated  a string containing links for all tsdb nodes present in the cluster