### PR TITLE
PNDA-4537: Metrics retention needs to be set per-flavor

### DIFF
--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -45,6 +45,9 @@
             "parallelism": 1,
             "taskmanager_mem_preallocate": false,
             "pyflink_yarn_container_count": 1
+        },
+        "graphite-api":{
+            "retention_spark_metrics": "60:1440"
         }
     }
 }

--- a/pillar/flavors/production.sls
+++ b/pillar/flavors/production.sls
@@ -45,6 +45,9 @@
             "parallelism": 1,
             "taskmanager_mem_preallocate": false,
             "pyflink_yarn_container_count": 1
+        },
+        "graphite-api":{
+            "retention_spark_metrics": "60:20160"
         }
     }
 }

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -45,6 +45,9 @@
             "parallelism": 1,
             "taskmanager_mem_preallocate": false,
             "pyflink_yarn_container_count": 1
+        },
+        "graphite-api":{
+            "retention_spark_metrics": "60:10080"
         }
     }
 }

--- a/salt/graphite-api/files/storage-schemas.conf.tpl
+++ b/salt/graphite-api/files/storage-schemas.conf.tpl
@@ -30,7 +30,7 @@ retentions = 60:43200
 
 [spark]
 pattern = ^spark\..*
-retentions = 60:10080
+retentions = {{ retentions }}
 
 [default]
 pattern = .*

--- a/salt/graphite-api/files/whitelist.conf
+++ b/salt/graphite-api/files/whitelist.conf
@@ -1,9 +1,4 @@
 # metrics name which will be accepted by carbon
-([0-9]+)\.executor\.filesystem\.file\.write_bytes
-([0-9]+)\.executor\.filesystem\.file\.largeRead_ops
-([0-9]+)\.executor\.filesystem\.file\.write_ops
-([0-9]+)\.executor\.filesystem\.file\.read_ops
-([0-9]+)\.executor\.filesystem\.file\.read_bytes
 ([0-9]+)\.executor\.filesystem\.hdfs\.write_bytes
 ([0-9]+)\.executor\.filesystem\.hdfs\.largeRead_ops
 ([0-9]+)\.executor\.filesystem\.hdfs\.write_ops
@@ -13,88 +8,156 @@
 ([0-9]+)\.executor\.threadpool\.maxPool_size
 ([0-9]+)\.executor\.threadpool\.currentPool_size
 ([0-9]+)\.executor\.threadpool\.completeTasks
-([0-9]+)\.jvm\.pools\.PS-Eden-Space\.committed
-([0-9]+)\.jvm\.pools\.PS-Eden-Space\.max
-([0-9]+)\.jvm\.pools\.PS-Eden-Space\.used
-([0-9]+)\.jvm\.pools\.Metaspace\.committed
-([0-9]+)\.jvm\.pools\.Metaspace\.max
-([0-9]+)\.jvm\.pools\.Metaspace\.used
-([0-9]+)\.jvm\.pools\.Compressed-Class-Space\.committed
-([0-9]+)\.jvm\.pools\.Compressed-Class-Space\.max
-([0-9]+)\.jvm\.pools\.Compressed-Class-Space\.used
-([0-9]+)\.jvm\.pools\.Code-Cache\.committed
-([0-9]+)\.jvm\.pools\.Code-Cache\.max
-([0-9]+)\.jvm\.pools\.Code-Cache\.used
-([0-9]+)\.jvm\.pools\.PS-Survivor-Space\.committed
-([0-9]+)\.jvm\.pools\.PS-Survivor-Space\.max
-([0-9]+)\.jvm\.pools\.PS-Survivor-Space\.used
-([0-9]+)\.jvm\.pools\.PS-Old-Gen\.committed
-([0-9]+)\.jvm\.pools\.PS-Old-Gen\.max
-([0-9]+)\.jvm\.pools\.PS-Old-Gen\.used
-([0-9]+)\.jvm\.PS-MarkSweep\.time
-([0-9]+)\.jvm\.PS-MarkSweep\.count
 ([0-9]+)\.jvm\.heap\.committed
+([0-9]+)\.jvm\.heap\.usage
 ([0-9]+)\.jvm\.heap\.max
-([0-9]+)\.jvm\.heap\.used
+([0-9]+)\.jvm\.heap\.init
 ([0-9]+)\.jvm\.total\.committed
 ([0-9]+)\.jvm\.total\.max
+([0-9]+)\.jvm\.total\.init
 ([0-9]+)\.jvm\.total\.used
-([0-9]+)\.jvm\.PS-Scavenge\.time
-([0-9]+)\.jvm\.PS-Scavenge\.count
 ([0-9]+)\.jvm\.non-heap\.committed
+([0-9]+)\.jvm\.non-heap\.usage
 ([0-9]+)\.jvm\.non-heap\.max
-([0-9]+)\.jvm\.non-heap\.used
+([0-9]+)\.jvm\.non-heap\.init
 driver\.ExecutorAllocationManager\.executors\.numberExecutorsPendingToRemove
 driver\.ExecutorAllocationManager\.executors\.numberMaxNeededExecutors
 driver\.ExecutorAllocationManager\.executors\.numberAllExecutors
 driver\.ExecutorAllocationManager\.executors\.numberTargetExecutors
 driver\.ExecutorAllocationManager\.executors\.numberExecutorsToAdd
-driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastReceivedBatch_processingStartTime
 driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.totalProcessedRecords
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastCompletedBatch_processingStartTime
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastCompletedBatch_processingEndTime
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastReceivedBatch_processingStartTime
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastReceivedBatch_processingEndTime
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastCompletedBatch_schedulingDelay
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastCompletedBatch_processingDelay
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastCompletedBatch_submissionTime
 driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.totalReceivedRecords
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastCompletedBatch_totalDelay
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.waitingBatches
 driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.runningBatches
-driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.receivers
+driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastReceivedBatch_submissionTime
 driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.unprocessedBatches
 driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.totalCompletedBatches
-driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastCompletedBatch_processingStartTime
-driver\.BlockManager\.disk\.diskSpaceUsed_MB
-driver\.BlockManager\.memory\.maxMem_MB
-driver\.BlockManager\.memory\.memUsed_MB
 driver\.BlockManager\.memory\.remainingMem_MB
-driver\.jvm\.pools\.PS-Eden-Space\.committed
-driver\.jvm\.pools\.PS-Eden-Space\.max
-driver\.jvm\.pools\.PS-Eden-Space\.used
-driver\.jvm\.pools\.Metaspace\.committed
-driver\.jvm\.pools\.Metaspace\.max
-driver\.jvm\.pools\.Metaspace\.used
-driver\.jvm\.pools\.Compressed-Class-Space\.committed
-driver\.jvm\.pools\.Compressed-Class-Space\.max
-driver\.jvm\.pools\.Compressed-Class-Space\.used
-driver\.jvm\.pools\.Code-Cache\.committed
-driver\.jvm\.pools\.Code-Cache\.max
-driver\.jvm\.pools\.Code-Cache\.used
-driver\.jvm\.PS-MarkSweep\.time
-driver\.jvm\.PS-MarkSweep\.count
 driver\.jvm\.heap\.committed
+driver\.jvm\.heap\.usage
 driver\.jvm\.heap\.max
-driver\.jvm\.heap\.used
-driver\.jvm\.total\.committed
+driver\.jvm\.heap\.init
 driver\.jvm\.total\.max
+driver\.jvm\.total\.init
 driver\.jvm\.total\.used
-driver\.jvm\.PS-Scavenge\.time
-driver\.jvm\.PS-Scavenge\.count
 driver\.jvm\.non-heap\.committed
+driver\.jvm\.non-heap\.usage
 driver\.jvm\.non-heap\.max
-driver\.jvm\.non-heap\.used
-driver\.DAGScheduler\.messageProcessingTime\.min
-driver\.DAGScheduler\.messageProcessingTime\.m1_rate
-driver\.DAGScheduler\.messageProcessingTime\.max
+driver\.jvm\.non-heap\.init
+driver\.DAGScheduler\.messageProcessingTime\.stddev
+driver\.DAGScheduler\.messageProcessingTime\.mean_rate
 driver\.DAGScheduler\.messageProcessingTime\.mean
+driver\.DAGScheduler\.messageProcessingTime\.count
 driver\.DAGScheduler\.stage\.failedStages
 driver\.DAGScheduler\.stage\.runningStages
 driver\.DAGScheduler\.stage\.waitingStages
 driver\.DAGScheduler\.job\.activeJobs
 driver\.DAGScheduler\.job\.allJobs
+# Below spark metrics are not being accepted by carbon. 
+# Please uncomment the metrics if want to capture.
+# ([0-9]+)\.executor\.filesystem\.file\.write_bytes
+# ([0-9]+)\.executor\.filesystem\.file\.largeRead_ops
+# ([0-9]+)\.executor\.filesystem\.file\.write_ops
+# ([0-9]+)\.executor\.filesystem\.file\.read_ops
+# ([0-9]+)\.executor\.filesystem\.file\.read_bytes
+# ([0-9]+)\.jvm\.pools\.PS-Eden-Space\.committed
+# ([0-9]+)\.jvm\.pools\.PS-Eden-Space\.usage
+# ([0-9]+)\.jvm\.pools\.PS-Eden-Space\.max
+# ([0-9]+)\.jvm\.pools\.PS-Eden-Space\.init
+# ([0-9]+)\.jvm\.pools\.PS-Eden-Space\.used
+# ([0-9]+)\.jvm\.pools\.Metaspace\.committed
+# ([0-9]+)\.jvm\.pools\.Metaspace\.usage
+# ([0-9]+)\.jvm\.pools\.Metaspace\.max
+# ([0-9]+)\.jvm\.pools\.Metaspace\.init
+# ([0-9]+)\.jvm\.pools\.Metaspace\.used
+# ([0-9]+)\.jvm\.pools\.Compressed-Class-Space\.committed
+# ([0-9]+)\.jvm\.pools\.Compressed-Class-Space\.usage
+# ([0-9]+)\.jvm\.pools\.Compressed-Class-Space\.max
+# ([0-9]+)\.jvm\.pools\.Compressed-Class-Space\.init
+# ([0-9]+)\.jvm\.pools\.Compressed-Class-Space\.used
+# ([0-9]+)\.jvm\.pools\.Code-Cache\.committed
+# ([0-9]+)\.jvm\.pools\.Code-Cache\.usage
+# ([0-9]+)\.jvm\.pools\.Code-Cache\.max
+# ([0-9]+)\.jvm\.pools\.Code-Cache\.init
+# ([0-9]+)\.jvm\.pools\.Code-Cache\.used
+# ([0-9]+)\.jvm\.pools\.PS-Survivor-Space\.committed
+# ([0-9]+)\.jvm\.pools\.PS-Survivor-Space\.usage
+# ([0-9]+)\.jvm\.pools\.PS-Survivor-Space\.max
+# ([0-9]+)\.jvm\.pools\.PS-Survivor-Space\.init
+# ([0-9]+)\.jvm\.pools\.PS-Survivor-Space\.used
+# ([0-9]+)\.jvm\.pools\.PS-Old-Gen\.committed
+# ([0-9]+)\.jvm\.pools\.PS-Old-Gen\.usage
+# ([0-9]+)\.jvm\.pools\.PS-Old-Gen\.max
+# ([0-9]+)\.jvm\.pools\.PS-Old-Gen\.init
+# ([0-9]+)\.jvm\.pools\.PS-Old-Gen\.used
+# ([0-9]+)\.jvm\.PS-MarkSweep\.time
+# ([0-9]+)\.jvm\.PS-MarkSweep\.count
+# ([0-9]+)\.jvm\.PS-Scavenge\.time
+# ([0-9]+)\.jvm\.PS-Scavenge\.count
+# ([0-9]+)\.jvm\.heap\.used
+# ([0-9]+)\.jvm\.non-heap\.used
+# driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.retainedCompletedBatches
+# driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.lastReceivedBatch_records
+# driver\.([A-Za-z0-9-_]+)\.StreamingMetrics\.streaming\.receivers
+# driver\.BlockManager\.disk\.diskSpaceUsed_MB
+# driver\.BlockManager\.memory\.maxMem_MB
+# driver\.BlockManager\.memory\.memUsed_MB
+# driver\.jvm\.pools\.PS-Eden-Space\.committed
+# driver\.jvm\.pools\.PS-Eden-Space\.usage
+# driver\.jvm\.pools\.PS-Eden-Space\.max
+# driver\.jvm\.pools\.PS-Eden-Space\.init
+# driver\.jvm\.pools\.PS-Eden-Space\.used
+# driver\.jvm\.pools\.Metaspace\.committed
+# driver\.jvm\.pools\.Metaspace\.usage
+# driver\.jvm\.pools\.Metaspace\.max
+# driver\.jvm\.pools\.Metaspace\.init
+# driver\.jvm\.pools\.Metaspace\.used
+# driver\.jvm\.pools\.Compressed-Class-Space\.committed
+# driver\.jvm\.pools\.Compressed-Class-Space\.usage
+# driver\.jvm\.pools\.Compressed-Class-Space\.max
+# driver\.jvm\.pools\.Compressed-Class-Space\.init
+# driver\.jvm\.pools\.Compressed-Class-Space\.used
+# driver\.jvm\.pools\.Code-Cache\.committed
+# driver\.jvm\.pools\.Code-Cache\.usage
+# driver\.jvm\.pools\.Code-Cache\.max
+# driver\.jvm\.pools\.Code-Cache\.init
+# driver\.jvm\.pools\.Code-Cache\.used
+# driver\.jvm\.pools\.PS-Survivor-Space\.committed
+# driver\.jvm\.pools\.PS-Survivor-Space\.usage
+# driver\.jvm\.pools\.PS-Survivor-Space\.max
+# driver\.jvm\.pools\.PS-Survivor-Space\.init
+# driver\.jvm\.pools\.PS-Survivor-Space\.used
+# driver\.jvm\.pools\.PS-Old-Gen\.committed
+# driver\.jvm\.pools\.PS-Old-Gen\.usage
+# driver\.jvm\.pools\.PS-Old-Gen\.max
+# driver\.jvm\.pools\.PS-Old-Gen\.init
+# driver\.jvm\.pools\.PS-Old-Gen\.used
+# driver\.jvm\.PS-MarkSweep\.time
+# driver\.jvm\.PS-MarkSweep\.count
+# driver\.jvm\.PS-Scavenge\.time
+# driver\.jvm\.PS-Scavenge\.count
+# driver\.DAGScheduler\.messageProcessingTime\.min
+# driver\.DAGScheduler\.messageProcessingTime\.m1_rate
+# driver\.DAGScheduler\.messageProcessingTime\.m5_rate
+# driver\.DAGScheduler\.messageProcessingTime\.m15_rate
+# driver\.DAGScheduler\.messageProcessingTime\.max
+# driver\.DAGScheduler\.messageProcessingTime\.p98
+# driver\.DAGScheduler\.messageProcessingTime\.p50
+# driver\.DAGScheduler\.messageProcessingTime\.p75
+# driver\.DAGScheduler\.messageProcessingTime\.p95
+# driver\.DAGScheduler\.messageProcessingTime\.p98
+# driver\.DAGScheduler\.messageProcessingTime\.p99
+# driver\.DAGScheduler\.messageProcessingTime\.p999
+# driver\.jvm\.heap\.used
+# driver\.jvm\.non-heap\.used
 ^zookeeper*
 ^tsd*
 ^kafka*

--- a/salt/graphite-api/init.sls
+++ b/salt/graphite-api/init.sls
@@ -1,4 +1,5 @@
 {% from "graphite-api/map.jinja" import config with context %}
+{% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
 
 graphite-api-carbon-install:
   pkg.installed:
@@ -7,7 +8,10 @@ graphite-api-carbon-install:
 graphite-api-carbon-configure:
   file.managed:
     - name: /etc/carbon/storage-schemas.conf
-    - source: salt://graphite-api/files/storage-schemas.conf
+    - source: salt://graphite-api/files/storage-schemas.conf.tpl
+    - template: jinja
+    - context:
+      retentions: {{ flavor_cfg.retention_spark_metrics }}
     - require:
       - pkg: graphite-api-carbon-install
 


### PR DESCRIPTION
**Problem Statement:**
PNDA-4537: Metrics retention needs to be set per-flavor

**Changes:**
1. Set retention settings in Pillar for each flavor.
2. Updated default list of metrics to capture for spark applications.

**Test details:**
AWS-RHEL-PICO-HDP