### PR TITLE
PNDA-4422: After disabling selinux and rebooting, SLS to set selinux to permissive fails

### DIFF
--- a/salt/pnda/user.sls
+++ b/salt/pnda/user.sls
@@ -9,6 +9,7 @@ pnda-install_selinux:
       - policycoreutils-python
       - selinux-policy-targeted
 
+{% if salt['cmd.run']('getenforce')|lower != 'disabled' %}
 permissive:
   selinux.mode: []
   file.replace:
@@ -17,6 +18,7 @@ permissive:
     - repl: 'SELINUX=permissive'
     - append_if_not_found: True
     - show_changes: True
+{% endif %}
 
 pnda-create_pnda_user:
   user.present:


### PR DESCRIPTION
Analysis:
Setting SELinux mode as "permissive" is failed in SaltStack, if SELinux mode as "disabled"

salt SELinux module: https://github.com/saltstack/salt/blob/2015.8/salt/modules/selinux.py#L41

Solution:
Skip SELinux permissive mode setting if SELinux is "disabled" using getenforce command.

Files modified:
platform-salt/salt/pnda/user.sls

Tested:
Develop:
RHEL HDP pico