### PR TITLE
PNDA-4409: modified hadopp-httpfs service file

### DIFF
--- a/salt/hdp/files/hadoop-httpfs.service
+++ b/salt/hdp/files/hadoop-httpfs.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=The Hadoop httpfs daemon
+After=network.target network-online.target
+Requires=network.target network-online.target
+
+[Service]
+Type=forking
+User=httpfs
+Group=hadoop
+Restart=on-failure
+WorkingDirectory=-/var/run/hadoop-httpfs
+
+Environment=SERVICE_NAME=httpfs
+Environment=HTTPFS_RUN=/var/run/hadoop-httpfs/httpfs
+Environment=HTTPFS_LOG=/var/log/hadoop-httpfs/httpfs
+Environment=CONF_DIR=/usr/hdp/current/hadoop-httpfs/../hadoop/conf
+
+Environment=HTTPFS_USER=httpfs
+Environment=HTTPFS_CONFIG=/usr/hdp/current/hadoop-httpfs/../hadoop/conf
+Environment=HTTPFS_TEMP=/var/run/hadoop-httpfs/httpfs
+Environment=HTTPFS_SLEEP_TIME=5
+
+Environment=CATALINA_BASE=/etc/hadoop-httpfs/tomcat-deployment
+Environment=CATALINA_PID=/var/run/hadoop-httpfs/httpfs/hadoop-httpfs-httpfs.pid
+Environment=CATALINA_TMPDIR=/var/run/hadoop-httpfs/httpfs
+
+PermissionsStartOnly=true
+
+ExecStartPre=/bin/sh -c 'test -d $HTTPFS_RUN || mkdir -p $HTTPFS_RUN ; chown -R httpfs:hadoop $HTTPFS_RUN; chmod -R 755 $HTTPFS_RUN'
+ExecStartPre=/bin/sh -c 'test -d $HTTPFS_LOG || mkdir -p $HTTPFS_LOG ; chown -R httpfs:hadoop $HTTPFS_LOG; chmod -R 755 $HTTPFS_LOG'
+
+ExecStartPre=/bin/sh -c 'test -d $CATALINA_BASE || mkdir $CATALINA_BASE ; rm -rf $CATALINA_BASE/webapp ; ln -sf /usr/hdp/current/hadoop-httpfs/webapps $CATALINA_BASE ; chown -R httpfs:hadoop $CATALINA_BASE ; chmod -R 755 $CATALINA_BASE'
+
+#Detect JAVA_HOME
+ExecStartPre=/bin/sh -c ' [ -e /etc/profile.d/jdk.sh ] && . /etc/profile.d/jdk.sh; ( [ $JAVA_HOME ] && echo "JAVA_HOME=$JAVA_HOME" || echo "JAVA_HOME=$(dirname $(dirname $(readlink -f  /usr/bin/java)))") > /var/run/hadoop-httpfs/httpfs/%n.env'
+EnvironmentFile=-/var/run/hadoop-httpfs/httpfs/%n.env
+
+ExecStart=/usr/hdp/current/hadoop-httpfs/sbin/httpfs.sh start $SERVICE_NAME httpfs
+ExecStop=/usr/hdp/current/hadoop-httpfs/sbin/httpfs.sh stop $SERVICE_NAME httpfs
+
+PIDFile=/var/run/hadoop-httpfs/httpfs/hadoop-httpfs-httpfs.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/hdp/httpfs.sls
+++ b/salt/hdp/httpfs.sls
@@ -4,21 +4,26 @@ hdp-httpfs_pkg:
     - name: hadoop-httpfs
     - ignore_epoch: True
 
-hdp-httpfs_create_link:
-  file.symlink:
-    - name: /etc/init.d/hadoop-httpfs
-    - target: /usr/hdp/current/hadoop-httpfs/etc/init.d/hadoop-httpfs
-
 hdp-httpfs_java_home:
   file.append:
     - name: /etc/hadoop-httpfs/conf/httpfs-env.sh
     - text:
       - "export JAVA_HOME=/usr/lib/jvm/java-8-oracle/"
 
+hdp-httpfs_service_add_file:
+  file.managed:
+    - name: /usr/hdp/current/hadoop-httpfs/usr/lib/systemd/system/hadoop-httpfs.service
+    - source: salt://hdp/files/hadoop-httpfs.service
+
 hdp-httpfs_service_started:
   service.running:
     - name: hadoop-httpfs
     - enable: True
     - reload: True
+
+
+
+
+
 
 


### PR DESCRIPTION
**Analysis**: There is bug with the httpfs systemd file, provided as part of the package. This service file create /var/run/hadoop-httpfs dir using "httpfs" user. The 'httpfs' doesn't have permission hence service fails after reboot the system.


**Resolution:** Modify 'hadoop-httpfs' systemd service file which is created by hadoop-httpfs package deployment for the action of directory creation by the root user and provide permission for 'httpfs' user.



