### PR TITLE
PNDA-4543: DM accepts Spark_Oozie_jobs for the wrong version

### DIFF
--- a/salt/deployment-manager/templates/dm-config.json.tpl
+++ b/salt/deployment-manager/templates/dm-config.json.tpl
@@ -53,7 +53,7 @@
 {% set resource_manager_path = pillar['resource_manager']['path'] %}
 
 {% set admin_user = pillar['deployment_manager']['admin_user'] %}
-
+{% set oozie_spark_version = pillar['hdp']['oozie_spark_version'] %}
 
 {
     "environment": {
@@ -86,6 +86,7 @@
         "environment_sync_interval": 120,
         "package_callback": "{{ data_logger_link }}/packages",
         "application_callback": "{{ data_logger_link }}/applications",
-        "package_repository": "{{ repository_manager_link }}"
+        "package_repository": "{{ repository_manager_link }}",
+        "oozie_spark_version": "{{ oozie_spark_version }}"
     }
 }


### PR DESCRIPTION
**Problem Statement:**
Deployment Manager accepts Spark Oozie jobs for the wrong version of Spark.

**Changes Done:**
Add Oozie spark version in dm-config.json.tpl.

**Test Details:**
PICO_HDP_RHEL with oozie version 1 
PICO_HDP_RHEL with oozie version 2.