### PR TITLE
PNDA-4543: Handling wrong oozie spark version request

### DIFF
--- a/salt/deployment-manager/templates/dm-config.json.tpl
+++ b/salt/deployment-manager/templates/dm-config.json.tpl
@@ -52,6 +52,8 @@
 
 {% set resource_manager_path = pillar['resource_manager']['path'] %}
 
+{% set oozie_spark_version = pillar['hdp']['oozie_spark_version'] %}
+
 {
     "environment": {
         "hadoop_distro":"{{ hadoop_distro }}",
@@ -82,6 +84,7 @@
         "environment_sync_interval": 120,
         "package_callback": "{{ data_logger_link }}/packages",
         "application_callback": "{{ data_logger_link }}/applications",
-        "package_repository": "{{ repository_manager_link }}"
+        "package_repository": "{{ repository_manager_link }}",
+        "oozie_spark_version": "{{ oozie_spark_version }}"
     }
 }


### PR DESCRIPTION
**Problem Statement:**
Deployment Manager accepts Spark Oozie jobs for the wrong version of Spark.

**Changes Done:**
Added Oozie spark version in dm-config.tpl file.

**Test Details:**
PICO_HDP_RHEL with oozie version 1
PICO_HDP_RHEL with oozie version  2