### PR TITLE
PNDA-4265: Route socket.io through front end HTTP server and reverse …

### DIFF
--- a/salt/console-frontend/init.sls
+++ b/salt/console-frontend/init.sls
@@ -11,7 +11,6 @@
 {% set frontend_version = salt['pillar.get']('console_frontend:release_version', 'unknown') %}
 {% set km_port = salt['pillar.get']('kafkamanager:bind_port', 10900) %}
 {% set hadoop_distro = grains['hadoop.distro'] %}
-
 {% set data_manager_host = salt['pnda.get_hosts_for_role']('console_backend_data_manager')[0] %}
 {% set data_manager_port = salt['pillar.get']('console_backend_data_manager:bind_port', '3123') %}
 {% set data_manager_version = salt['pillar.get']('console_backend_data_manager:release_version', 'unknown') %}
@@ -112,6 +111,8 @@ console-frontend-create_pnda_nginx_config:
     - defaults:
         console_dir: {{ console_dir }}
         port: {{ nginx_port }}
+        data_manager_host: {{ data_manager_host }}
+        data_manager_port: {{ data_manager_port }}
 
 # Remove default nginx configuration
 console-frontend-remove_nginx_default_config:

--- a/salt/console-frontend/templates/PNDA_nginx.conf.tpl
+++ b/salt/console-frontend/templates/PNDA_nginx.conf.tpl
@@ -1,8 +1,12 @@
+upstream websocket {
+	server {{ data_manager_host }}:{{ data_manager_port }};
+}
+
 server {
 	listen {{port}} default_server;
 
 	root {{ console_dir }};
-	index index.html index.htm;
+	index index.html index.htm; 
 
 	# Make site accessible from http://localhost/
 	server_name localhost;
@@ -14,6 +18,13 @@ server {
 		# Uncomment to enable naxsi on this location
 		# include /etc/nginx/naxsi.rules
 	}
+
+	location /socket.io/ {
+    	proxy_pass http://websocket;
+    	proxy_http_version 1.1;
+    	proxy_set_header Upgrade $http_upgrade;
+    	proxy_set_header Connection "upgrade";
+    }
 
 	#error_page 500 502 503 504 /50x.html;
 	#location = /50x.html {


### PR DESCRIPTION
## Problem statement
Current implementation requires an additional port through to the socket.io server. Thus drill a hole in the firewall to the edge node. This also causes CORS complications.

## Update 
- add reverse proxy configuration to nginx configuration
- update url mappings for port forwarding to socket.io service.
- update console-frontend state file

## Tests
- CentOS/PICO
