### PR TITLE
Remove admin_user setting from deployment-manager config

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -71,7 +71,6 @@ console_backend_utils:
 deployment_manager:
   release_version: develop
   keys_directory: /opt/pnda/dm_keys
-  admin_user: pnda
 
 package_repository:
   release_version: develop

--- a/salt/deployment-manager/templates/dm-config.json.tpl
+++ b/salt/deployment-manager/templates/dm-config.json.tpl
@@ -52,9 +52,6 @@
 
 {% set resource_manager_path = pillar['resource_manager']['path'] %}
 
-{% set admin_user = pillar['deployment_manager']['admin_user'] %}
-
-
 {
     "environment": {
         "hadoop_distro":"{{ hadoop_distro }}",
@@ -78,7 +75,6 @@
         "flink": "{{ resource_manager_path }}/bin/flink"
     },
     "config": {
-        "admin_user": "{{ admin_user }}",
         "stage_root": "stage",
         "plugins_path": "plugins",
         "log_level": "INFO",


### PR DESCRIPTION
Remove admin_user setting from deployment-manager config as users may now placed in arbitrary groups to assign authorization rights.

PNDA-4560