### PR TITLE
Add option for services to register their own DNS entry

### DIFF
--- a/salt/deployment-manager/templates/deployment-manager.service.tpl
+++ b/salt/deployment-manager/templates/deployment-manager.service.tpl
@@ -4,6 +4,7 @@ Description=deployment manager service
 [Service]
 Type=simple
 WorkingDirectory={{ install_dir }}/deployment_manager
+ExecStartPre=/opt/pnda/utils/register-service.sh deployment-manager-internal 5000
 ExecStart={{ install_dir }}/deployment_manager/venv/bin/python {{ install_dir }}/deployment_manager/app.py
 Restart=always
 RestartSec=2

--- a/salt/package-repository/templates/package-repository.service.tpl
+++ b/salt/package-repository/templates/package-repository.service.tpl
@@ -4,6 +4,7 @@ Description=package repository service
 [Service]
 Type=simple
 WorkingDirectory={{ install_dir }}/package_repository
+ExecStartPre=/opt/pnda/utils/register-service.sh package-repository-internal 8888
 ExecStart={{ install_dir }}/package_repository/venv/bin/python {{ install_dir }}/package_repository/package_repository_rest_server.py
 Restart=always
 RestartSec=2

--- a/salt/service-self-registration/files/register-service.sh
+++ b/salt/service-self-registration/files/register-service.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Register a service on this host with Consul
+# Parameters:
+#  $1 - service name
+#  $2 - port
+#  IP address is automatically determined with hostname --ip-address
+curl --request PUT --data "{\"ID\": \"$1\",\"Name\": \"$1\",\"Address\": \"$(hostname --ip-address)\",\"Port\": $2}"  http://$(hostname --ip-address):8500/v1/agent/service/register

--- a/salt/service-self-registration/init.sls
+++ b/salt/service-self-registration/init.sls
@@ -1,0 +1,13 @@
+service-self-registration-dir:
+  file.directory:
+    - name: /opt/pnda/utils
+    - mode: 644
+    - makedirs: True
+
+service-self-registration-script:
+  file.managed:
+    - name: /opt/pnda/utils/register-service.sh
+    - source: salt://service-self-registration/files/register-service.sh
+    - mode: 755
+    - require:
+      - file: service-self-registration-dir

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -7,6 +7,7 @@
     - pnda.user
     - identity.users
     - hostsfile
+    - service-self-registration
     - java
     - java.env
     - ntp


### PR DESCRIPTION
Install a helper script register-service.sh that allows a service to register a service DNS entry with Consul and use it to register the Deployment Manager on service startup.

PNDA-4386