### PR TITLE
PNDA-4053: Change owner to ambari for /var/run/ambari-server

### DIFF
--- a/salt/ambari/files/ambari-server-permission
+++ b/salt/ambari/files/ambari-server-permission
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# chkconfig: 345 95 20
+# description: set owner of pid directory of ambari-server
+# processname: ambari-server-permission
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### BEGIN INIT INFO
+# Provides:          ambari-server-permission
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Start:
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 6
+### END INIT INFO
+
+AMBARI_SERVER_DIR="/var/run/ambari-server"
+
+if [ ! -d "$AMBARI_SERVER_DIR" ]; then
+   mkdir "$AMBARI_SERVER_DIR"
+   chown ambari:root "$AMBARI_SERVER_DIR"
+else
+   chown ambari:root "$AMBARI_SERVER_DIR"
+fi
+
+exit $?

--- a/salt/ambari/server.sls
+++ b/salt/ambari/server.sls
@@ -153,6 +153,18 @@ ambari-server-setup_mysql:
   cmd.run:
     - name: 'ambari-server setup --jdbc-db=mysql --jdbc-driver=/usr/share/java/mysql-connector-java.jar; ambari-server setup --jdbc-db=bdb --jdbc-driver=/opt/pnda/jdbc-driver/{{ jdbc_package }}'
 
+ambari-server-pid-dir_permission_service_script:
+  file.managed:
+    - name: /etc/init.d/ambari-server-permission
+    - source: salt://ambari/files/ambari-server-permission
+    - mode: 755
+
+ambari-server-pid-dir_permission_service_add:
+  cmd.run:
+    - name: |
+        chkconfig --add  ambari-server-permission
+        chkconfig --level 2345 ambari-server-permission on
+
 ambari-server-start_service:
   cmd.run:
     - name: 'service ambari-server stop || echo already stopped; service ambari-server start'


### PR DESCRIPTION
**Problem Statement:**
Failed in add service via Ambari due to no permissions to create folders under /var/run/ambari-server

**Changes Done:**
Added new service to create the /var/run/ambari-server  directory  with "ambari:root" user after rebooting the node which will fix the permission issue to add the new services in ambari. 

**Test Details:**
AWS-PICO-HDP-RHEL