### PR TITLE
Configure knox to proxy hadoop services

### DIFF
--- a/salt/cdh/hue-login.sls
+++ b/salt/cdh/hue-login.sls
@@ -1,4 +1,4 @@
-{% set hue_server = salt['pnda.get_hosts_by_role']('HUE', 'HUE_SERVER')[0] %}
+{% set hue_server = salt['pnda.get_hosts_by_hadoop_role']('HUE', 'HUE_SERVER')[0] %}
 
 cdh-hue_script_copy:
   file.managed:

--- a/salt/hdp/oozie_libs.sls
+++ b/salt/hdp/oozie_libs.sls
@@ -1,6 +1,6 @@
 {% set scripts_location = '/tmp/pnda-install/' + sls %}
-{% set httpfs_node = salt['pnda.get_hosts_by_role']('HDFS', 'NAMENODE')[0] %}
-{% set oozie_node = salt['pnda.get_hosts_by_role']('OOZIE', 'OOZIE_SERVER')[0] %}
+{% set httpfs_node = salt['pnda.get_hosts_by_hadoop_role']('HDFS', 'NAMENODE')[0] %}
+{% set oozie_node = salt['pnda.get_hosts_by_hadoop_role']('OOZIE', 'OOZIE_SERVER')[0] %}
 {% set pip_index_url = pillar['pip']['index_url'] %}
 {% set oozie_spark_version = salt['pillar.get']('hdp:oozie_spark_version', '1') %}
 

--- a/salt/hdp/templates/cfg_pico.py.tpl
+++ b/salt/hdp/templates/cfg_pico.py.tpl
@@ -372,7 +372,8 @@ BLUEPRINT = r'''{
                     "javax.jdo.option.ConnectionDriverName" : "com.mysql.jdbc.Driver",
                     "javax.jdo.option.ConnectionPassword" : "hive",
                     "javax.jdo.option.ConnectionURL" : "jdbc:mysql://%(cluster_name)s-hadoop-mgr-1%(domain_name)s/hive?createDatabaseIfNotExist=true",
-                    "javax.jdo.option.ConnectionUserName" : "hive"
+                    "javax.jdo.option.ConnectionUserName" : "hive",
+                    "hive.server2.transport.mode": "http"
                 }
             }
         },

--- a/salt/hdp/templates/cfg_production.py.tpl
+++ b/salt/hdp/templates/cfg_production.py.tpl
@@ -408,7 +408,8 @@ BLUEPRINT = r'''{
                     "javax.jdo.option.ConnectionDriverName" : "com.mysql.jdbc.Driver",
                     "javax.jdo.option.ConnectionPassword" : "hive",
                     "javax.jdo.option.ConnectionURL" : "jdbc:mysql://%(cluster_name)s-hadoop-mgr-4%(domain_name)s/hive?createDatabaseIfNotExist=true",
-                    "javax.jdo.option.ConnectionUserName" : "hive"
+                    "javax.jdo.option.ConnectionUserName" : "hive",
+                    "hive.server2.transport.mode": "http"
                 }
             }
         },

--- a/salt/hdp/templates/cfg_standard.py.tpl
+++ b/salt/hdp/templates/cfg_standard.py.tpl
@@ -384,7 +384,8 @@ BLUEPRINT = r'''{
                     "javax.jdo.option.ConnectionDriverName" : "com.mysql.jdbc.Driver",
                     "javax.jdo.option.ConnectionPassword" : "hive",
                     "javax.jdo.option.ConnectionURL" : "jdbc:mysql://%(cluster_name)s-hadoop-mgr-4%(domain_name)s/hive?createDatabaseIfNotExist=true",
-                    "javax.jdo.option.ConnectionUserName" : "hive"
+                    "javax.jdo.option.ConnectionUserName" : "hive",
+                    "hive.server2.transport.mode": "http"
                 }
             }
         },

--- a/salt/knox/init.sls
+++ b/salt/knox/init.sls
@@ -5,9 +5,11 @@
 {% set pnda_mirror = pillar['pnda_mirror']['base_url'] %}
 {% set misc_packages_path = pillar['pnda_mirror']['misc_packages_path'] %}
 {% set mirror_location = pnda_mirror + misc_packages_path %}
-{% set namenode_host = salt['pnda.get_hosts_by_role']('HDFS', 'NAMENODE')[0] %}
-{% set oozie_node = salt['pnda.get_hosts_by_role']('OOZIE', 'OOZIE_SERVER')[0] %}
-{% set hive_node = salt['pnda.get_hosts_by_role']('HIVE', 'HIVE_SERVER')[0] %}
+{% set namenode_host = salt['pnda.get_hosts_by_hadoop_role']('HDFS', 'NAMENODE')[0] %}
+{% set hive_host = salt['pnda.get_hosts_by_hadoop_role']('HIVE', 'HIVE_SERVER')[0] %}
+{% set webhdfs_host = salt['pnda.get_hosts_by_hadoop_node']('MGR01')[0] %}
+{% set hbase_rest_host = salt['pnda.get_hosts_by_hadoop_node']('MGR01')[0] %}
+{% set yarn_rm_host = salt['pnda.get_hosts_by_hadoop_role']('YARN', 'RESOURCEMANAGER')[0] %}
 {% set pnda_domain = pillar['consul']['data_center'] + '.' + pillar['consul']['domain'] %}
 {% set release_directory = pillar['pnda']['homedir'] %}
 {% set knox_home_directory = release_directory + '/knox' %}
@@ -154,8 +156,10 @@ knox-set-configuration:
     - context:
       knox_authentication: {{ knox_authentication }}
       namenode_host: {{ namenode_host }}
-      oozie_node: {{ oozie_node }}
-      hive_node: {{ hive_node }}
+      webhdfs_host: {{ webhdfs_host }}
+      hbase_rest_host: {{ hbase_rest_host }} 
+      yarn_rm_host: {{ yarn_rm_host }}
+      hive_host: {{ hive_host }}
       pnda_domain: {{ pnda_domain }}
     - require:
       - cmd: knox-init-authentication

--- a/salt/knox/templates/pnda.xml.tpl
+++ b/salt/knox/templates/pnda.xml.tpl
@@ -46,38 +46,18 @@
     </gateway>
 
     <service>
-        <role>NAMENODE</role>
-        <url>hdfs://{{ namenode_host }}:8020</url>
-    </service>
-
-    <service>
-        <role>JOBTRACKER</role>
-        <url>rpc://{{ namenode_host }}:8050</url>
-    </service>
-
-    <service>
         <role>WEBHDFS</role>
-        <url>http://{{ namenode_host }}:50070/webhdfs</url>
-    </service>
-
-    <service>
-        <role>OOZIE</role>
-        <url>http://{{ oozie_node }}:11000/oozie</url>
+        <url>http://{{ webhdfs_host }}:14000/webhdfs</url>
     </service>
 
     <service>
         <role>WEBHBASE</role>
-        <url>http://{{ namenode_host }}:8080</url>
+        <url>http://{{ hbase_rest_host }}:20550</url>
     </service>
 
     <service>
         <role>HIVE</role>
-        <url>http://{{ hive_node }}:10001/cliservice</url>
-    </service>
-
-    <service>
-        <role>RESOURCEMANAGER</role>
-        <url>http://{{ namenode_host }}:8088/ws</url>
+        <url>http://{{ hive_host }}:10001/cliservice</url>
     </service>
 
     <service>
@@ -88,6 +68,16 @@
     <service>
         <role>pnda-package-repository</role>
         <url>http://package-repository-internal.service.{{ pnda_domain }}:8888</url>
+    </service>
+
+    <service>
+        <role>YARN</role>
+        <url>http://{{ yarn_rm_host }}:8088</url>
+    </service>
+
+    <service>
+        <role>YARNUI</role>
+        <url>http://{{ yarn_rm_host }}:8088</url>
     </service>
 
 </topology>

--- a/salt/pnda_opentsdb/conf.sls
+++ b/salt/pnda_opentsdb/conf.sls
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% set hadoop_zk = [] %}
-{% for ip in salt['pnda.get_hosts_by_role'](zk_service, zk_role) %}
+{% for ip in salt['pnda.get_hosts_by_hadoop_role'](zk_service, zk_role) %}
 {% do hadoop_zk.append(ip+':2181') %}
 {% endfor %}
 


### PR DESCRIPTION
Update pnda knox topology:
 - Remove services we don't use
 - Point knox at hadoop services we do use based on where those roles actually are
 - Use http transport for hive to allow this to work with knox
 - Add YARN and YARNUI roles for YARN Resource Manager UI

Also rename salt functions used to find CDH and HDP roles to make it clear that these use hadoop roles and not pnda roles to find endpoints.

PNDA-4583

add yarn ui