### PR TITLE
Refactor the yarn client cli wrappers to manipulate the PATH env

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -96,7 +96,7 @@ platformlib:
   target_directory: "/opt/pnda"
 
 resource_manager:
-  path: /opt/pnda/rm-wrapper/
+  path: /opt/pnda/rm-wrapper
   policy_file: yarn-policy.sh
 
 jmxproxy:

--- a/salt/deployment-manager/templates/dm-config.json.tpl
+++ b/salt/deployment-manager/templates/dm-config.json.tpl
@@ -49,6 +49,9 @@
 
 {% set policy_file_link = pillar['resource_manager']['path'] + pillar['resource_manager']['policy_file'] %}
 
+{% set resource_manager_path = pillar['resource_manager']['path'] %}
+
+
 {
     "environment": {
         "hadoop_distro":"{{ hadoop_distro }}",
@@ -66,7 +69,8 @@
         "jupyter_host": "{{ jupyter_host }}",
         "jupyter_notebook_directory": "jupyter_notebooks",
         "app_packages_hdfs_path":"{{ app_packages_hdfs_path }}",
-        "queue_policy": "{{ policy_file_link }}"
+        "queue_policy": "{{ policy_file_link }}",
+        "spark_submit": "{{ resource_manager_path }}/bin/spark-submit"
     },
     "config": {
         "stage_root": "stage",

--- a/salt/jupyter/jupyter.sls
+++ b/salt/jupyter/jupyter.sls
@@ -5,7 +5,7 @@
 {% set app_packages_home = pnda_home_directory + '/app-packages' %}
 {% set jupyter_extension_venv = pnda_home_directory + '/jupyter-extensions' %}
 {% set pnda_user  = pillar['pnda']['user'] %}
-{% set wrapper_spark_home = '/usr/' %}
+{% set wrapper_spark_home = pillar['resource_manager']['path'] %}
 {% set features = salt['pillar.get']('features', []) %}
 {% if grains['hadoop.distro'] == 'HDP' %}
 {% set anaconda_home = '/opt/pnda/anaconda' %}

--- a/salt/resource-manager/init.sls
+++ b/salt/resource-manager/init.sls
@@ -1,5 +1,5 @@
 {% set resource_manager_path = pillar['resource_manager']['path'] %}
-{% set map_file = resource_manager_path + "policies/map.txt" %}
+{% set map_file = resource_manager_path + "/policies/map.txt" %}
 {% set policy_file_link = resource_manager_path + pillar['resource_manager']['policy_file'] %}
 {% set execs = [ 'spark-submit', 'spark-shell', 'pyspark', 'mapred', 'hive', 'beeline' ] %} 
 {% if grains['hadoop.distro'] == 'HDP' %}
@@ -42,7 +42,7 @@ resource-manager_log:
 
 resource-manager_spark_common_wrapper:
   file.managed:
-    - name: {{ resource_manager_path }}/yarn-common-wrapper.sh
+    - name: {{ resource_manager_path }}/bin/yarn-common-wrapper.sh
     - source: salt://resource-manager/templates/yarn-common-wrapper.sh
     - template: jinja
     - defaults:
@@ -50,46 +50,24 @@ resource-manager_spark_common_wrapper:
         policy_file_link: {{ policy_file_link }}
         log_file: '/var/log/pnda/wrapper.log'
     - mode: 755
+    - makedirs: True
+
+resource-manager_profile_sh:
+  file.managed:
+    - name: /etc/profile.d/wrapper.sh
+    - contents: 'PATH={{ resource_manager_path }}/bin:$PATH'
+
+resource-manager_profile_csh:
+  file.managed:
+    - name: /etc/profile.d/wrapper.csh
+    - contents: 'PATH={{ resource_manager_path }}/bin:$PATH'
 
 {% for exec in execs %}
 
 resource-manager_{{ exec }}:
   file.symlink:
-    - name: {{ resource_manager_path }}/{{ exec }}
-    - target: {{ resource_manager_path }}/yarn-common-wrapper.sh
+    - name: {{ resource_manager_path }}/bin/{{ exec }}
+    - target: {{ resource_manager_path }}/bin/yarn-common-wrapper.sh
     - mode: 755
 
-resource-manager_{{ exec }}_move:
-  file.rename:
-    - name: /opt/pnda/rm-client/{{ exec }}
-    - source: /usr/bin/{{ exec }}
-    - makedirs: True
-    - onlyif:
-      - echo " ! ls -q /opt/pnda/rm-client/{{ exec }}" | /bin/bash
-      - echo " ! readlink /usr/bin/{{ exec }} | fgrep -q /etc/alternatives/" | /bin/bash
-
-resource-manager_{{ exec }}_orig:
-  alternatives.install:
-    - name: {{ exec }}
-    - link: /usr/bin/{{ exec }}
-    - path: /opt/pnda/rm-client/{{ exec }}
-    - priority: 10
-    - onlyif:
-      - test -x /opt/pnda/rm-client/{{ exec }}
-
-resource-manager_{{ exec }}_wrapper:
-  alternatives.install:
-    - name: {{ exec }}
-    - link: /usr/bin/{{ exec }}
-    - path: {{ resource_manager_path }}/{{ exec }}
-    - priority: 100
-
 {% endfor %}
-
-resource-manager_spark_script_move:
-  file.rename:
-    - name: /opt/pnda/rm-client/spark-script-wrapper.sh
-    - source: /usr/bin/spark-script-wrapper.sh
-    - makedirs: True
-    - onlyif: 
-      - test -x /usr/bin/spark-script-wrapper.sh

--- a/salt/resource-manager/templates/yarn-common-wrapper.sh
+++ b/salt/resource-manager/templates/yarn-common-wrapper.sh
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
 # Find which script to call
-CALLER_DIR="$(cd "`dirname "$0"`"; pwd)"
 CLI=`basename "$0"`
-if [ "$CALLER_DIR" == "/usr/bin" ] || [ "$CALLER_DIR" == "/bin" ] || [ "$CALLER_DIR" == "{{ resource_manager_path }}" ]; then
-  # The wrapper (or master alternative) is the caller, so we can now call the original script.
-  EXECUTABLE="$(update-alternatives --display "$CLI" | egrep -v '^/bin' | egrep -v '^/usr/bin' | egrep -v '^{{ resource_manager_path }}' | egrep -o ^/.*"$CLI" | head -n 1)"
-  if [ "X$EXECUTABLE" == "X" ]; then
-    echo "There is no alternative for $CLI"
-    exit 1
-  fi
-else
-  EXECUTABLE="/usr/bin/$CLI"
-fi
 
 if [ $CLI == "hive" ] || [ $CLI == "beeline" ]; then
 #--hiveconf tez.queue.name=dev
@@ -74,5 +63,9 @@ set -- "${KEEP[@]}"
 
 # Call the script with all the arguments.
 [[ "X$WRAPPED_SPARK_HOME" != 'X' ]] && export SPARK_HOME=$WRAPPED_SPARK_HOME
-echo "Executing: $EXECUTABLE $@"
-exec "$EXECUTABLE" "$@"
+REM={{ resource_manager_path }}/bin
+REM=${REM//\//\\/}
+PATH=${PATH/$REM:/}
+echo "Setting PATH=$PATH"
+echo "Executing: $CLI $@"
+exec "$CLI" "$@"


### PR DESCRIPTION
The previous implementation was manipulating the alternatives but this
doesn't appears to be robust against upgrades. During the upgrade the
alternatives are being manipulated by the hadoop distro itself hence
resetting the wrappers modification.
The new implementation hence now manipulates the PATH instead to insert
the wrapper in front of the wrapped cli managed by hadoop.

PNDA-4511