### PR TITLE
PNDA-4664: Start data-logger/data-manager post redis service

### DIFF
--- a/salt/console-backend/templates/backend_nodejs_app.service.tpl
+++ b/salt/console-backend/templates/backend_nodejs_app.service.tpl
@@ -1,5 +1,6 @@
 [Unit]
 Description=concole backend app
+After=redis.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
**Problem Statement:**
data-manager and data-logger services are not starting properly after reboot the system.

**Changes Done:**
Updated service script of data-manager and data-logger to start after redis service.

**Test Details:**
AWS-PICO-HDP-RHEL