### PR TITLE
PNDA-4541: Lots of small logs are not cleaned up efficiently by log-rotate

### DIFF
--- a/salt/logserver/logserver.sls
+++ b/salt/logserver/logserver.sls
@@ -47,6 +47,12 @@ logserver-copy_logrotate:
     - name: /etc/logrotate.d/pnda
     - source: salt://logserver/logserver_files/logrotate.conf
 
+logserver-copy_compress_logs_script:
+  file.managed:
+    - name: /opt/pnda/utils/compress_yarn_logs.sh
+    - source: salt://logserver/logserver_templates/compress_yarn_logs.sh.tpl
+    - mode: 755
+
 logserver-update-crontab:
   cron.present:
     - identifier: LOGROTATE
@@ -63,10 +69,10 @@ logserver-add_crontab_entry1:
 
 logserver-add_crontab_entry2:
   cron.present:
-    - identifier: DELETE-YARN-APP-ZERO
-    - name: /usr/bin/find /var/log/pnda -name 'yarn-application*' -type f -size 0 -delete
+    - identifier: COMPRESS-YARN-APP-LOGS
+    - name: /usr/bin/sh /opt/pnda/utils/compress_yarn_logs.sh
     - user: root
-    - minute: 15
+    - minute: '*/5'
 
 logserver-add_crontab_entry3:
   cron.present:

--- a/salt/logserver/logserver_templates/compress_yarn_logs.sh.tpl
+++ b/salt/logserver/logserver_templates/compress_yarn_logs.sh.tpl
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+/usr/bin/find /var/log/pnda/ -name 'yarn-application_*.log' -type f -mmin +120 |
+while read -r i;
+do
+    filename=${i##*/};
+    cd /var/log/pnda;
+    if [ -f "yarn-applications_$(date +%m%d%Y).tar.gz" ];
+    then
+        tar -uf yarn-applications_$(date +%m%d%Y).tar.gz $filename --remove-files;
+    else
+        tar -cvf yarn-applications_$(date +%m%d%Y).tar.gz $filename --remove-files;
+    fi;
+done


### PR DESCRIPTION
# Problem Statement:
PNDA-4541: Lots of small logs are not cleaned up efficiently by log-rotate

# Changes:
Approach used - 
cronjob is added to monitor the /var/log/pnda folder for yarn applications logs. 
It will look for yarn applications log every 5 minutes which are not accessed within last 2 hrs and will add such logs to a compressed zip reducing the number of inactive yarn logs in the folder and maintaining a single compressed zip for each day.

# Test details
RHEL - PICO - CDH & HDP