### PR TITLE
Align directory permissions with file permissions

### DIFF
--- a/salt/service-self-registration/init.sls
+++ b/salt/service-self-registration/init.sls
@@ -1,7 +1,7 @@
 service-self-registration-dir:
   file.directory:
     - name: /opt/pnda/utils
-    - mode: 644
+    - mode: 751
     - makedirs: True
 
 service-self-registration-script:


### PR DESCRIPTION
File allows execution by all, but directory doesn't. 
Added execute to directory for all.