### PR TITLE
Configure Knox to proxy PNDA console

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -56,7 +56,8 @@ platform_gobblin_modules:
 
 console_frontend:
   release_version: develop
-
+  bind_port: 80
+  
 console_backend_data_logger:
   release_version: develop
   bind_port: 3001

--- a/salt/_modules/pnda.py
+++ b/salt/_modules/pnda.py
@@ -143,9 +143,7 @@ def generate_external_link(role, suffix):
     fqdn = __salt__['pillar.get'](role+':fqdn')
     log.info('generate_external_link: cert=%s' % cert)
     log.info('generate_external_link: fqdn=%s' % fqdn)
-    if cert and fqdn:
-        return 'https://%s%s' % (fqdn, suffix)
-    return generate_http_link(role, suffix)
+    return 'http%s://%s%s' % ('s' if cert else '', fqdn, suffix) if fqdn else ''
 
 def cloudera_get_hosts_by_hadoop_role(service, role_type):
     user = hadoop_manager_username()

--- a/salt/console-frontend/init.sls
+++ b/salt/console-frontend/init.sls
@@ -30,14 +30,18 @@
 {% set cm_port = ':8080' %}
 {%- endif -%}
 
-# Set links
+# Set direct links
 {% set hadoop_manager_link = salt['pnda.generate_http_link']('hadoop_manager', cm_port) %}
 {% set km_link = salt['pnda.generate_http_link']('kafka_manager',':'+km_port|string+'/clusters/'+clustername) %}
 {% set opentsdb_link = salt['pnda.generate_http_link']('opentsdb',':' + opentsdb_port|string) %}
-{% set grafana_link = salt['pnda.generate_http_link']('grafana',':3000') %}
 {% set kibana_link = salt['pnda.generate_http_link']('logserver',':5601') %}
-{% set jupyter_link = salt['pnda.generate_external_link']('jupyter',':8000') %}
-{% set flink_link = salt['pnda.generate_external_link']('flink',':8082') %}
+{% set flink_link = salt['pnda.generate_http_link']('flink',':8082') %}
+
+# Set links through gateway roles
+{% set yarn_link = salt['pnda.generate_external_link']('knox',':8443/gateway/pnda/yarn') %}
+{% set jupyter_link = salt['pnda.generate_external_link']('haproxy',':8444/jupyter') %}
+{% set grafana_link = salt['pnda.generate_external_link']('haproxy',':8444/grafana') %}
+
 {% set login_mode = 'PAM' %}
 
 include:
@@ -101,6 +105,7 @@ console-frontend-create_pnda_console_config:
         kibana_link: "{{ kibana_link }}"
         jupyter_link: "{{ jupyter_link }}"
         flink_link: "{{ flink_link }}"
+        yarn_link: "{{ yarn_link }}"
         login_mode: "{{ login_mode }}"
 
 # Create a configuration file for nginx and specify where the PNDA console file are

--- a/salt/console-frontend/templates/PNDA.json.tpl
+++ b/salt/console-frontend/templates/PNDA.json.tpl
@@ -30,6 +30,10 @@
     {
       "name": "Flink",
       "link": "{{ flink_link }}"
+    },
+    {
+      "name": "YARN Resource Manager",
+      "link": "{{ yarn_link }}"
     }
   ],
   "frontend": {

--- a/salt/console-frontend/templates/PNDA_nginx.conf.tpl
+++ b/salt/console-frontend/templates/PNDA_nginx.conf.tpl
@@ -19,7 +19,7 @@ server {
 		# include /etc/nginx/naxsi.rules
 	}
 
-	location /socket.io/ {
+	location /updates/socket.io/ {
     		proxy_http_version 1.1;
     		proxy_set_header Upgrade $http_upgrade;
     		proxy_set_header Connection "upgrade";

--- a/salt/knox/files/console_rewrite.xml
+++ b/salt/knox/files/console_rewrite.xml
@@ -1,0 +1,73 @@
+<rules>
+    <rule dir="IN" name="PNDACONSOLE/console/inbound/rootnoslash" pattern="*://*:*/**/console">
+        <rewrite template="{$serviceUrl[PNDACONSOLE]}/"/>
+    </rule>
+    <rule dir="IN" name="PNDACONSOLE/console/inbound/root" pattern="*://*:*/**/console/">
+        <rewrite template="{$serviceUrl[PNDACONSOLE]}/"/>
+    </rule>
+    <rule dir="IN" name="PNDACONSOLE/console/inbound/socket" pattern="*://*:*/**/console/updates/socket.io/?{**}">
+        <rewrite template="{$serviceUrl[PNDACONSOLE]}/updates/socket.io/?{**}"/>
+    </rule>
+    <rule dir="IN" name="PNDACONSOLE/console/inbound/pathquery" pattern="*://*:*/**/console/{**}?{**}">
+        <rewrite template="{$serviceUrl[PNDACONSOLE]}/{**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="PNDACONSOLE/console/inbound/path" pattern="*://*:*/**/console/{**}">
+        <rewrite template="{$serviceUrl[PNDACONSOLE]}/{**}"/>
+    </rule>
+    <rule dir="IN" name="PNDACONSOLE/console/inbound/metrics" pattern="*://*:*/**/console/api/dm/metrics/?{**}">
+        <rewrite template="{$serviceUrl[PNDACONSOLE]}/api/dm/metrics/?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/css" pattern="/css/{**}">
+        <rewrite template="{$frontend[path]}/console/css/{**}"/>
+    </rule>
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/js" pattern="/js/{**}">
+        <rewrite template="{$frontend[path]}/console/js/{**}"/>
+    </rule>
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/nodemodules" pattern="/node_modules/{**}">
+        <rewrite template="{$frontend[path]}/console/node_modules/{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/help">
+        <match pattern="help/{**}"/>
+        <rewrite template="{$frontend[path]}/console/help/{**}"/>
+    </rule>
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/partials">
+        <match pattern="partials/{**}"/>
+        <rewrite template="{$frontend[path]}/console/partials/{**}"/>
+    </rule>
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/config">
+        <match pattern="conf/{**}"/>
+        <rewrite template="{$frontend[path]}/console/conf/{**}"/>
+    </rule>
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/pam">
+        <match pattern="pam/{**}"/>
+        <rewrite template="{$frontend[path]}/console/pam/{**}"/>
+    </rule>
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/metrics">
+        <rewrite template="{$frontend[path]}/console/api/dm/metrics/:metricId?values=y"/>
+    </rule>
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/api">
+        <match pattern="api/dm/{**}"/>
+        <rewrite template="{$frontend[path]}/console/api/dm/{**}"/>
+    </rule>
+    <rule dir="OUT" name="PNDACONSOLE/console/outbound/socket">
+        <rewrite template="{$frontend[path]}/console/updates/socket.io"/>
+    </rule>
+
+    <filter name="PNDACONSOLE/console/outbound/app">
+        <content type="application/javascript">
+            <apply path="help\/.*.json" rule="PNDACONSOLE/console/outbound/help"/>
+            <apply path="\/?partials\/.*.html" rule="PNDACONSOLE/console/outbound/partials"/>
+            <apply path="\/?conf\/.*.json" rule="PNDACONSOLE/console/outbound/config"/>
+            <apply path="\/pam\/login" rule="PNDACONSOLE/console/outbound/pam"/>
+            <apply path="\/pam\/logout" rule="PNDACONSOLE/console/outbound/pam"/>
+            <apply path="\/api\/dm\/metrics\/:metricId\?values=y" rule="PNDACONSOLE/console/outbound/metrics"/>
+            <apply path="\/api\/dm\/endpoints" rule="PNDACONSOLE/console/outbound/api"/>
+            <apply path="\/api\/dm\/applications" rule="PNDACONSOLE/console/outbound/api"/>
+            <apply path="\/api\/dm\/packages" rule="PNDACONSOLE/console/outbound/api"/>
+            <apply path="\/api\/dm\/datasets" rule="PNDACONSOLE/console/outbound/api"/>
+            <apply path="\/updates\/socket\.io" rule="PNDACONSOLE/console/outbound/socket"/>
+       </content>
+    </filter>
+</rules>

--- a/salt/knox/files/console_service.xml
+++ b/salt/knox/files/console_service.xml
@@ -1,0 +1,34 @@
+<service role="PNDACONSOLE" name="console" version="1.0.0">
+    <policies>
+        <policy role="webappsec"/>
+        <policy role="authentication" name="Anonymous"/>
+        <policy role="rewrite"/>
+        <policy role="authorization"/>
+    </policies>
+    <routes>
+
+    <route path="/console/updates/socket.io">
+      <rewrite apply="PNDACONSOLE/console/inbound/socket" to="request.url"/>
+    </route>
+
+    <route path="/console/api/dm/metrics">
+      <rewrite apply="PNDACONSOLE/console/inbound/metrics" to="request.url"/>
+    </route>
+
+    <route path="/console/">
+      <rewrite apply="PNDACONSOLE/console/inbound/root" to="request.url"/>
+    </route>
+
+    <route path="/console/**">
+      <rewrite apply="PNDACONSOLE/console/inbound/path" to="request.url"/>
+      <rewrite apply="PNDACONSOLE/console/outbound/app" to="response.body"/>
+    </route>
+
+    <route path="/console/**?**">
+      <rewrite apply="PNDACONSOLE/console/inbound/pathquery" to="request.url"/>
+      <rewrite apply="PNDACONSOLE/console/outbound/app" to="response.body"/>
+    </route>
+
+   </routes>
+ <dispatch classname="org.apache.hadoop.gateway.dispatch.PassAllHeadersDispatch"/>
+</service>

--- a/salt/knox/files/gateway-site.xml
+++ b/salt/knox/files/gateway-site.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+
+    <property>
+        <name>gateway.port</name>
+        <value>8443</value>
+        <description>The HTTP port for the Gateway.</description>
+    </property>
+
+    <property>
+        <name>gateway.path</name>
+        <value>gateway</value>
+        <description>The default context path for the gateway.</description>
+    </property>
+
+    <property>
+        <name>gateway.gateway.conf.dir</name>
+        <value>deployments</value>
+        <description>The directory within GATEWAY_HOME that contains gateway topology files and deployments.</description>
+    </property>
+
+    <property>
+        <name>gateway.hadoop.kerberos.secured</name>
+        <value>false</value>
+        <description>Boolean flag indicating whether the Hadoop cluster protected by Gateway is secured with Kerberos</description>
+    </property>
+
+    <property>
+        <name>java.security.krb5.conf</name>
+        <value>/etc/knox/conf/krb5.conf</value>
+        <description>Absolute path to krb5.conf file</description>
+    </property>
+
+    <property>
+        <name>java.security.auth.login.config</name>
+        <value>/etc/knox/conf/krb5JAASLogin.conf</value>
+        <description>Absolute path to JAAS login config file</description>
+    </property>
+
+    <property>
+        <name>sun.security.krb5.debug</name>
+        <value>true</value>
+        <description>Boolean flag indicating whether to enable debug messages for krb5 authentication</description>
+    </property>
+
+    <!-- @since 0.10 Websocket configs -->
+    <property>
+        <name>gateway.websocket.feature.enabled</name>
+        <value>true</value>
+        <description>Enable/Disable websocket feature.</description>
+    </property>
+
+    <property>
+        <name>gateway.scope.cookies.feature.enabled</name>
+        <value>true</value>
+        <description>Enable/Disable cookie scoping feature.</description>
+    </property>
+
+    <property>
+        <name>gateway.cluster.config.monitor.ambari.enabled</name>
+        <value>false</value>
+        <description>Enable/disable Ambari cluster configuration monitoring.</description>
+    </property>
+
+    <property>
+        <name>gateway.cluster.config.monitor.ambari.interval</name>
+        <value>60</value>
+        <description>The interval (in seconds) for polling Ambari for cluster configuration changes.</description>
+    </property>
+
+</configuration>

--- a/salt/knox/init.sls
+++ b/salt/knox/init.sls
@@ -144,6 +144,11 @@ knox-set-configuration:
     - require:
       - cmd: knox-init-authentication
 
+knox-configure-gateway-site:
+  file.managed:
+    - name: {{ conf_directory }}/gateway-site.xml
+    - source: salt://knox/files/gateway-site.xml
+
 knox-enable_pam_login:
   file.managed:
     - name: /etc/shadow
@@ -207,7 +212,8 @@ knox-import_CA:
 {% set knox_proxy_services = {
   'dm': 'pnda-deployment-manager/1.0.0/',
   'pr':  'pnda-package-repository/1.0.0/',
-  'tsdb': 'opentsdb/' + opentsdb_version + '/'
+  'tsdb': 'opentsdb/' + opentsdb_version + '/',
+  'console': 'pnda-console/1.0.0'
   } %}
 
 {% for service_name in knox_proxy_services %}

--- a/salt/knox/templates/pnda.xml.tpl
+++ b/salt/knox/templates/pnda.xml.tpl
@@ -77,4 +77,9 @@
         <url>http://opentsdb-internal.service.{{ pnda_domain }}:{{ opentsdb_port }}</url>
     </service>
 
+    <service>
+        <role>PNDACONSOLE</role>
+        <url>http://console-internal.service.{{ pnda_domain }}</url>
+    </service>
+
 </topology>

--- a/salt/nginx/init.sls
+++ b/salt/nginx/init.sls
@@ -1,3 +1,5 @@
+{% set console_port = pillar['console_frontend']['bind_port'] %}
+
 nginx-pkg:
   pkg.installed:
     - name: {{ pillar['nginx']['package-name'] }}
@@ -8,6 +10,15 @@ nginx_conf_file:
   file.managed:
     - name: /etc/nginx/nginx.conf
     - source: salt://nginx/files/nginx.conf
+
+nginx-service-script:
+  file.managed:
+    - name: /usr/lib/systemd/system/nginx.service
+    - source: salt://{{ sls }}/templates/nginx.service.tpl
+    - mode: 0644
+    - template: jinja
+    - context:
+        console_port: {{ console_port }}
 
 nginx-systemctl_reload:
   cmd.run:

--- a/salt/nginx/templates/nginx.service.tpl
+++ b/salt/nginx/templates/nginx.service.tpl
@@ -1,0 +1,22 @@
+[Unit]
+Description=The nginx HTTP and reverse proxy server
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=/run/nginx.pid
+# Nginx will fail to start if /run/nginx.pid already exists but has the wrong
+# SELinux context. This might happen when running `nginx -t` from the cmdline.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1268621
+ExecStartPre=/usr/bin/rm -f /run/nginx.pid
+ExecStartPre=/usr/sbin/nginx -t
+ExecStartPre=/opt/pnda/utils/register-service.sh console-internal {{ console_port }}
+ExecStart=/usr/sbin/nginx
+ExecReload=/bin/kill -s HUP $MAINPID
+KillSignal=SIGQUIT
+TimeoutStopSec=5
+KillMode=process
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This has a known issue - https://issues.pnda.io/browse/PNDA-4719 - which means that socket.io will fall back to long polling for updates from the console backend. 

This PR depends on corresponding PRs for PNDA-4569 in the console front and back end repositories and also PNDA-4643 for TLS support in HAProxy.

PNDA-4569