### PR TITLE
Move ldap-client from top.sls to base-services.sls

### DIFF
--- a/salt/base-services/init.sls
+++ b/salt/base-services/init.sls
@@ -1,0 +1,4 @@
+include:
+  - consul
+  - consul.dns
+  - ldap-client

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -11,7 +11,6 @@
     - java
     - java.env
     - ntp
-    - ldap-client
     - logserver.logshipper
 
   'roles:zookeeper':


### PR DESCRIPTION
Create a base-services sls that encapsulates consul and ldap. Do not install it in the main highstate because the minions must be restarted after it runs.

PNDA-4730