### PR TITLE
Ensure application ID considered part of path

### DIFF
--- a/salt/knox/files/yarnui_rewrite.xml
+++ b/salt/knox/files/yarnui_rewrite.xml
@@ -265,7 +265,7 @@
 
 <rule dir="OUT" name="YARNUI/yarn/outbound/apps/history">
     <match pattern="*://*:*/proxy/{**}"/>
-    <rewrite template="{$frontend[url]}/yarn/proxy/{**}"/>
+    <rewrite template="{$frontend[url]}/yarn/proxy/{**}/"/>
 </rule>
 <rule dir="OUT" name="YARNUI/yarn/outbound/apps/history1">
     <match pattern="/proxy/{**}"/>


### PR DESCRIPTION
The YARN web app expects paths to be qualified by application ID. The current rewrite rules omit the last slash, making the application ID be considered a 'file' rather than a 'path segment' by the browser. Therefore when you follow a link in the returned content like 'css/something.css' the complete URL  constructed will be the referrer path (which doesn't include application ID) plus the 'css/something.css'. The YARN web app sees the application ID as 'css' and throws a 500 error. 

Lengthy explanation as this seems to be a common problem in Knox and I think we'll see the same thing elsewhere. Solution here is to simply add a slash in the outbound content filter. 

PNDA-4723
