### PR TITLE
PNDA-4440: Upgrade Kafka from 0.11.0.2 to 1.1.0

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -16,7 +16,7 @@ zookeeper:
   version: 3.4.11
 
 kafka:
-  version: 0.11.0.2
+  version: 1.1.0
   internal_port: 9092
   replication_port: 9093
   ingest_port: 9094


### PR DESCRIPTION
Problem Statement:
Upgrade Kafka from 0.11.0.2 to 1.1.0

Changes Done:
Modified Kafka version to 1.1.0