### PR TITLE
PNDA-4536 Kafka data dirs to be configurable in pnda_env.yaml

### DIFF
--- a/pillar/flavors/bmstandard.sls
+++ b/pillar/flavors/bmstandard.sls
@@ -26,7 +26,6 @@
             "zookeeper_data_dir": "/var/lib/zookeeper"
         },
         "kafka.server": {
-            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824
         },
         "mysql": {

--- a/pillar/flavors/distribution.sls
+++ b/pillar/flavors/distribution.sls
@@ -17,7 +17,6 @@
             "zookeeper_data_dir": "/var/lib/zookeeper"
         },
         "kafka.server": {
-            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824
         },
         "mysql": {

--- a/pillar/flavors/pico.sls
+++ b/pillar/flavors/pico.sls
@@ -10,7 +10,6 @@
             "max_mappers": 5
         },
         "kafka.server": {
-            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 314572800,
             "kafka_heapsize": 2147483648
         },

--- a/pillar/flavors/production.sls
+++ b/pillar/flavors/production.sls
@@ -19,7 +19,6 @@
             "days_to_keep": 6
         },
         "kafka.server": {
-            "data_dirs": ["/mnt/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824,
             "kafka_heapsize": 17179869184
         },

--- a/pillar/flavors/standard.sls
+++ b/pillar/flavors/standard.sls
@@ -10,7 +10,6 @@
             "max_mappers": 50
         },
         "kafka.server": {
-            "data_dirs": ["/var/kafka-logs"],
             "kafka_log_retention_bytes": 1073741824,
             "kafka_heapsize": 4294967296
         },

--- a/salt/kafka-tool/init.sls
+++ b/salt/kafka-tool/init.sls
@@ -1,5 +1,5 @@
 #read all pillar data
-{% set flavor_cfg = pillar['pnda_flavor']['states']['kafka.server'] %}
+{% set data_dirs = pillar['kafka']['data_dirs'] %}
 
 {% set install_dir = pillar['pnda']['homedir'] %}
 {% set packages_server = pillar['packages_server']['base_uri'] %}
@@ -9,7 +9,7 @@
 
 {% set p  = salt['pillar.get']('kafka', {}) %}
 {% set local_kafka_path = p.get('prefix', '/opt/pnda/kafka') %}
-{% set kafka_log_path = flavor_cfg.data_dirs[0] %}
+{% set kafka_log_path = data_dirs[0] %}
 
 {%- set zk_ips = [] -%}
 {%- for ip in salt['pnda.kafka_zookeepers_hosts']() -%}

--- a/salt/kafka/server.sls
+++ b/salt/kafka/server.sls
@@ -37,9 +37,9 @@ kafka-directories:
       - user
       - group
     - names:
-{% for log_dir in config.log_dirs %}
+{%- for log_dir in config.log_dirs %}
       - {{ log_dir }}
-{% endfor %}
+{%- endfor %}
 
 kafka-server-conf:
   file.managed:

--- a/salt/kafka/settings.sls
+++ b/salt/kafka/settings.sls
@@ -2,7 +2,7 @@
 {% set pc = p.get('config', {}) %}
 {% set g  = salt['grains.get']('kafka', {}) %}
 {% set gc = g.get('config', {}) %}
-{% set flavor_cfg = pillar['pnda_flavor']['states']['kafka.server'] %}
+{% set data_dirs = pillar['kafka']['data_dirs'] %}
 
 # these are global - hence pillar-only
 {%- set prefix            = p.get('prefix', '/opt/pnda/kafka') %}
@@ -22,7 +22,7 @@
   'broker_id': gc.get('broker_id', pc.get('broker_id', 0)),
   'port': gc.get('port', pc.get('port', 9092)),
   'zookeeper_connect': gc.get('zookeeper_connect', pc.get('zookeeper_connect', 'localhost:2181')),
-  'log_dirs': flavor_cfg.data_dirs,
+  'log_dirs': data_dirs,
   'num_partitions': gc.get('num_partitions', pc.get('num_partitions', 2)),
   'log_retention_bytes': gc.get('log_retention_bytes', pc.get('log_retention_bytes', 16106127360)),
   'host_name': gc.get('host_name', pc.host_name),


### PR DESCRIPTION
Analysis:
Kafka data dirs to be configurable in pnda_env.yaml

Solution:
Added DATA_DIRS setting in pnda-env.yaml to set the data_dirs in the pillar
Added DEVICE_ROOT setting in pnda-env.yaml to set the disks in the volume-config.yaml

Tested:
RHEL HDP PICO
RHEL HDP STANDARD
RHEL HDP PRODUCTION