### PR TITLE
PNDA-4766: Enable access to Ambari through Knox

### DIFF
--- a/salt/console-frontend/init.sls
+++ b/salt/console-frontend/init.sls
@@ -31,7 +31,6 @@
 {%- endif -%}
 
 # Set direct links
-{% set hadoop_manager_link = salt['pnda.generate_http_link']('hadoop_manager', cm_port) %}
 {% set km_link = salt['pnda.generate_http_link']('kafka_manager',':'+km_port|string+'/clusters/'+clustername) %}
 {% set opentsdb_link = salt['pnda.generate_http_link']('opentsdb',':' + opentsdb_port|string) %}
 {% set kibana_link = salt['pnda.generate_http_link']('logserver',':5601') %}
@@ -39,6 +38,7 @@
 
 # Set links through gateway roles
 {% set yarn_link = salt['pnda.generate_external_link']('knox',':8443/gateway/pnda/yarn') %}
+{% set hadoop_manager_link = salt['pnda.generate_external_link']('knox',':8443/gateway/pnda/ambari') %}
 {% set jupyter_link = salt['pnda.generate_external_link']('haproxy',':8444/jupyter') %}
 {% set grafana_link = salt['pnda.generate_external_link']('haproxy',':8444/grafana') %}
 {% set httpfs_link = salt['pnda.generate_external_link']('knox',':8443/gateway/pnda/webhdfs') %}

--- a/salt/knox/init.sls
+++ b/salt/knox/init.sls
@@ -1,4 +1,3 @@
-{% set cfg_flavor = pillar['pnda_flavor']['name'] %}
 {% set knox_version = salt['pillar.get']('knox:release_version', '') %}
 {% set knox_authentication = salt['pillar.get']('knox:authentication', '') %}
 {% set knox_master_secret = salt['pillar.get']('knox:master_secret', '') %}
@@ -14,6 +13,7 @@
 {% set yarn_ha_enabled = (yarn_rm_hosts is not none and yarn_rm_hosts|length>1) %}
 {% set mr2_history_server_host = salt['pnda.get_hosts_by_hadoop_role']('MAPREDUCE2', 'HISTORYSERVER')[0] %}
 {% set spark_history_server_host = salt['pnda.get_hosts_by_hadoop_role']('SPARK', 'SPARK_JOBHISTORYSERVER')[0] %}
+{% set ambari_server_host = salt['pnda.get_hosts_for_role']('hadoop_manager')[0] %}
 {% set pnda_domain = pillar['consul']['data_center'] + '.' + pillar['consul']['domain'] %}
 {% set release_directory = pillar['pnda']['homedir'] %}
 {% set knox_home_directory = release_directory + '/knox' %}
@@ -148,6 +148,7 @@ knox-set-configuration:
       ha_enabled: {{ yarn_ha_enabled }}
       spark_history_server_host: {{ spark_history_server_host }}
       mr2_history_server_host: {{ mr2_history_server_host }}
+      ambari_server_host: {{ ambari_server_host }}
     - require:
       - cmd: knox-init-authentication
 

--- a/salt/knox/templates/pnda.xml.tpl
+++ b/salt/knox/templates/pnda.xml.tpl
@@ -107,4 +107,13 @@
         <url>http://console-internal.service.{{ pnda_domain }}</url>
     </service>
 
+    <service>
+        <role>AMBARI</role>
+        <url>http://{{ ambari_server_host }}:8080</url>
+    </service>
+
+    <service>
+        <role>AMBARIUI</role>
+        <url>http://{{ ambari_server_host }}:8080</url>
+    </service>
 </topology>


### PR DESCRIPTION
Changes:
    * Update PNDA topology configuration to include Ambari service
    * Update Console Frontend's Hadoop CM configuration

Tests:
   * PICO/CENTOS
   * STD/CENTOS 