### PR TITLE
PNDA-4795 Fix for CDH Hue-login orchestrate state not running

### DIFF
--- a/salt/cdh/hue-login.sls
+++ b/salt/cdh/hue-login.sls
@@ -9,4 +9,4 @@ cdh-hue_script_copy:
 
 cdh-hue_script_run:
   cmd.run:
-    - name: if [ "`hostname -s`" = "{{ hue_server }}" ]; then /tmp/hue-user-setup.sh; fi
+    - name: if [ "`hostname -f`" = "{{ hue_server }}" ]; then /tmp/hue-user-setup.sh; fi

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -43,7 +43,7 @@ orchestrate-pnda-impala_wrapper:
 
 orchestrate-pnda-hue_setup:
   salt.state:
-    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@hadoop:MGR*'
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@hadoop:role:MGR*'
     - tgt_type: compound
     - sls: cdh.hue-login
     - timeout: 120


### PR DESCRIPTION
Issue: Hue user creation not called, due to the wrong target in salt.


Solution: Added the proper grain to target the node.