### PR TITLE
PNDA-4797: ELK deployed twice in PICO Setup

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -34,14 +34,11 @@
     - jmxproxy
     - platform-testing.general
 
-  'roles:elk':
+  'roles:logserver':
     - match: grain
     - curator
     - elasticsearch
     - kibana
-
-  'roles:logserver':
-    - match: grain
     - logserver.logserver
 
   'roles:kibana_dashboard':


### PR DESCRIPTION
# Problem Statement:
PNDA-4797: ELK deployed twice in PICO Setup
dependency PR - https://github.com/pndaproject/pnda-cli/pull/146

# Changes:
- Added elk roles grains to the logserver.

# Test details
RHEL ( HDP & CDH ) PICO