### PR TITLE
PNDA-4705: Adhere to coding convention in Knox topology

### DIFF
--- a/salt/knox/files/dm_rewrite.xml
+++ b/salt/knox/files/dm_rewrite.xml
@@ -1,5 +1,5 @@
 <rules>
-    <rule dir="IN" name="pnda-deployment-manager" pattern="*://*:*/**/deployment/{**}?{**}">
-        <rewrite template="{$serviceUrl[pnda-deployment-manager]}/{**}?{**}"/>
+    <rule dir="IN" name="PNDA-DEPLOYMENT-MANAGER/pnda-deployment-manager/inbound" pattern="*://*:*/**/deployment/{**}?{**}">
+        <rewrite template="{$serviceUrl[PNDA-DEPLOYMENT-MANAGER]}/{**}?{**}"/>
     </rule>
 </rules>

--- a/salt/knox/files/dm_service.xml
+++ b/salt/knox/files/dm_service.xml
@@ -1,7 +1,7 @@
-<service role="pnda-deployment-manager" name="pnda-deployment-manager" version="1.0.0">
+<service role="PNDA-DEPLOYMENT-MANAGER" name="pnda-deployment-manager" version="1.0.0">
     <routes>
         <route path="/deployment/**">
-            <rewrite apply="pnda-deployment-manager" to="request.url"/>
+            <rewrite apply="PNDA-DEPLOYMENT-MANAGER/pnda-deployment-manager/inbound" to="request.url"/>
         </route>
     </routes>
 </service>

--- a/salt/knox/files/pr_rewrite.xml
+++ b/salt/knox/files/pr_rewrite.xml
@@ -1,5 +1,5 @@
 <rules>
-    <rule dir="IN" name="pnda-package-repository" pattern="*://*:*/**/repository/{**}?{**}">
-        <rewrite template="{$serviceUrl[pnda-package-repository]}/{**}?{**}"/>
+    <rule dir="IN" name="PNDA-PACKAGE-REPOSITORY/pnda-package-repository/inbound" pattern="*://*:*/**/repository/{**}?{**}">
+        <rewrite template="{$serviceUrl[PNDA-PACKAGE-REPOSITORY]}/{**}?{**}"/>
     </rule>
 </rules>

--- a/salt/knox/files/pr_service.xml
+++ b/salt/knox/files/pr_service.xml
@@ -1,7 +1,7 @@
-<service role="pnda-package-repository" name="pnda-package-repository" version="1.0.0">
+<service role="PNDA-PACKAGE-REPOSITORY" name="pnda-package-repository" version="1.0.0">
     <routes>
         <route path="/repository/**">
-            <rewrite apply="pnda-package-repository" to="request.url"/>
+            <rewrite apply="PNDA-PACKAGE-REPOSITORY/pnda-package-repository/inbound" to="request.url"/>
         </route>
     </routes>
 </service>

--- a/salt/knox/files/tsdb_rewrite.xml
+++ b/salt/knox/files/tsdb_rewrite.xml
@@ -1,8 +1,8 @@
 <rules>
-    <rule dir="IN" name="opentsdbq" pattern="*://*:*/**/opentsdb/api/query?{**}">
-        <rewrite template="{$serviceUrl[opentsdb]}/api/query?{**}"/>
+    <rule dir="IN" name="OPENTSDB/opentsdb/inbound/query" pattern="*://*:*/**/opentsdb/api/query?{**}">
+        <rewrite template="{$serviceUrl[OPENTSDB]}/api/query?{**}"/>
     </rule>
-    <rule dir="IN" name="opentsdbs" pattern="*://*:*/**/opentsdb/api/search?{**}">
-        <rewrite template="{$serviceUrl[opentsdb]}/api/search?{**}"/>
+    <rule dir="IN" name="OPENTSDB/opentsdb/inbound/search" pattern="*://*:*/**/opentsdb/api/search?{**}">
+        <rewrite template="{$serviceUrl[OPENTSDB]}/api/search?{**}"/>
     </rule>
 </rules>

--- a/salt/knox/files/tsdb_service.xml
+++ b/salt/knox/files/tsdb_service.xml
@@ -1,10 +1,10 @@
-<service role="opentsdb" name="opentsdb" version="1.0.0">
+<service role="OPENTSDB" name="opentsdb" version="1.0.0">
     <routes>
         <route path="/opentsdb/api/query?**">
-            <rewrite apply="opentsdbq" to="request.url"/>
+            <rewrite apply="OPENTSDB/opentsdb/inbound/query" to="request.url"/>
         </route>
         <route path="/opentsdb/api/search?**">
-            <rewrite apply="opentsdbs" to="request.url"/>
+            <rewrite apply="OPENTSDB/opentsdb/inbound/search" to="request.url"/>
         </route>
     </routes>
 </service>

--- a/salt/knox/templates/pnda.xml.tpl
+++ b/salt/knox/templates/pnda.xml.tpl
@@ -98,17 +98,17 @@
     </service>
 
     <service>
-        <role>pnda-deployment-manager</role>
+        <role>PNDA-DEPLOYMENT-MANAGER</role>
         <url>http://deployment-manager-internal.service.{{ pnda_domain }}:5000</url>
     </service>
 
     <service>
-        <role>pnda-package-repository</role>
+        <role>PNDA-PACKAGE-REPOSITORY</role>
         <url>http://package-repository-internal.service.{{ pnda_domain }}:8888</url>
     </service>
 
     <service>
-        <role>opentsdb</role>
+        <role>OPENTSDB</role>
         <url>http://opentsdb-internal.service.{{ pnda_domain }}:{{ opentsdb_port }}</url>
     </service>
 


### PR DESCRIPTION
Modified role names of "pnda-deployment-manager", "pnda-package-repository" & "opentsdb" from lower case to Upper case to align to the convention provided for other knox services

Also modified rewrite rule names to align to the convention for other service rewrite rules  