### PR TITLE
PNDA-4837: Upgrade Grafana version to 5.1.3

### DIFF
--- a/pillar/packages/CentOS.sls
+++ b/pillar/packages/CentOS.sls
@@ -47,7 +47,7 @@ gnuplot:
   package-name: gnuplot
   version: ""
 grafana:
-  package-source: 'grafana-4.2.0-1.x86_64.rpm'
+  package-source: 'grafana-5.1.3-1.x86_64.rpm'
 krb5-devel:
   package-name: krb5-devel
   version: ""

--- a/pillar/packages/RedHat.sls
+++ b/pillar/packages/RedHat.sls
@@ -47,7 +47,7 @@ gnuplot:
   package-name: gnuplot
   version: ""
 grafana:
-  package-source: 'grafana-4.2.0-1.x86_64.rpm'
+  package-source: 'grafana-5.1.3-1.x86_64.rpm'
 krb5-devel:
   package-name: krb5-devel
   version: ""


### PR DESCRIPTION
**Upgrade Grafana to latest stable release**

- Modified "CentOS.sls" & "RedHat.sls" with latest Grafana version 5.1.3