### PR TITLE
Install Ambari legacy metrics sink on Hadoop nodes

### DIFF
--- a/pillar/packages/CentOS.sls
+++ b/pillar/packages/CentOS.sls
@@ -7,6 +7,12 @@ ambari-agent:
 ambari-server:
   package-name: ambari-server
   version: "2.7.0.0-897"
+ambari-legacy-metrics-hadoop-sink:
+  package-name: ambari-metrics-hadoop-sink
+  version: "2.6.1.0-143"
+ambari-metrics-hadoop-sink:
+  package-name: ambari-metrics-hadoop-sink
+  version: "2.7.0.0-897"
 at:
   package-name: at
   version: ""

--- a/pillar/packages/RedHat.sls
+++ b/pillar/packages/RedHat.sls
@@ -7,6 +7,12 @@ ambari-agent:
 ambari-server:
   package-name: ambari-server
   version: "2.7.0.0-897"
+ambari-legacy-metrics-hadoop-sink:
+  package-name: ambari-metrics-hadoop-sink
+  version: "2.6.1.0-143"
+ambari-metrics-hadoop-sink:
+  package-name: ambari-metrics-hadoop-sink
+  version: "2.7.0.0-897"
 at:
   package-name: at
   version: ""

--- a/salt/ambari/metrics_sink.sls
+++ b/salt/ambari/metrics_sink.sls
@@ -1,0 +1,11 @@
+ambari-legacy-metrics-hadoop-sink-pkg:
+  pkg.installed:
+    - name: {{ pillar['ambari-legacy-metrics-hadoop-sink']['package-name'] }}
+    - version: {{ pillar['ambari-legacy-metrics-hadoop-sink']['version'] }}
+    - ignore_epoch: True
+
+ambari-metrics-hadoop-sink-pkg:
+  pkg.installed:
+    - name: {{ pillar['ambari-metrics-hadoop-sink']['package-name'] }}
+    - version: {{ pillar['ambari-metrics-hadoop-sink']['version'] }}
+    - ignore_epoch: True

--- a/salt/orchestrate/pnda-expand.sls
+++ b/salt/orchestrate/pnda-expand.sls
@@ -27,6 +27,14 @@ orchestrate-expand-install_hadoop:
 {% endif %}
 
 {% if grains['hadoop.distro'] == 'HDP' %}
+orchestrate-pnda-install_ambari_metrics_sink:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@hadoop:* and G@pnda:is_new_node'
+    - tgt_type: compound
+    - sls: ambari.metrics_sink
+    - timeout: 120
+    - queue: True
+
 orchestrate-expand-install_ambari_agents:
   salt.state:
     - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@hadoop:* and G@pnda:is_new_node'

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -51,6 +51,14 @@ orchestrate-pnda-hue_setup:
 {% endif %}
 
 {% if grains['hadoop.distro'] == 'HDP' %}
+orchestrate-pnda-install_ambari_metrics_sink:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@hadoop:*'
+    - tgt_type: compound
+    - sls: ambari.metrics_sink
+    - timeout: 120
+    - queue: True
+
 orchestrate-pnda-install_ambari_server:
   salt.state:
     - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@roles:hadoop_manager'


### PR DESCRIPTION
Enables metrics feed from HDP2.6 to Ambari2.7 by triggering 'legacy' metrics mechanics in Ambari at installation time.

PNDA-4836