### PR TITLE
PNDA-4860: Some logs coming into Kibana are big aggregated blob rather than time series

### DIFF
--- a/salt/logserver/logshipper_templates/shipper.conf.tpl
+++ b/salt/logserver/logshipper_templates/shipper.conf.tpl
@@ -11,7 +11,7 @@ input {
           add_field => {"source" => "knox"}
           sincedb_path => "{{ install_dir }}/logstash/sincedb/db"
           codec => multiline {
-            pattern => "^%{TIMESTAMP_ISO8601}"
+            pattern => "^%{YEAR}[-/]%{MONTHNUM}[-/]%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE}?"
             negate => true
             what => "previous"
           }


### PR DESCRIPTION
# Problem Statement:
PNDA-4860: Some logs coming into Kibana are big aggregated blob rather than time series

# Analysis:
logshipper filters the knox log and audit messages based on the TIMESTAMP_ISO8601 pattern in the message text. But, the knox audit log have the different timestamp pattern i.e. yy/MM/dd HH:mm:ss instead of expected ISO8601 grok pattern timestamp (yyyy-MM-dd HH:mm:ss). 

# Changes:
Changed the logshipper pattern so that it filters the messages for both timestamp patterns.

# Test details:
RHEL - PICO - HDP
Centos - PICO - CDH

# Reference:
https://github.com/elastic/logstash/blob/v1.4.2/patterns/grok-patterns