### PR TITLE
PNDA-4882: Modified service role from "YARN" to "RESOURCEMANAGER"

### DIFF
--- a/salt/knox/templates/pnda.xml.tpl
+++ b/salt/knox/templates/pnda.xml.tpl
@@ -44,6 +44,10 @@
                <name>YARNUI</name>
                <value>maxFailoverAttempts=3;failoverSleep=1000;enabled=true</value>
             </param>
+            <param>
+               <name>RESOURCEMANAGER</name>
+               <value>maxFailoverAttempts=3;failoverSleep=1000;enabled=true</value>
+            </param>
         </provider>
 {% endif %}
     </gateway>
@@ -68,9 +72,9 @@
     </service>
 
     <service>
-        <role>YARN</role>
+        <role>RESOURCEMANAGER</role>
         {% for item in yarn_rm_hosts %}
-            <url>http://{{ item }}:8088</url>
+            <url>http://{{ item }}:8088/ws</url>
         {% endfor %}
         
     </service>


### PR DESCRIPTION
1. Enabling RESOURCEMANAGER service to get cluster information through KNOX using REST APIs
2. Modified service role name from "YARN"(Doesn't exist) to "RESOURCEMANAGER" in KNOX topology and also added "RESOURCEMANAGER" service to HA provider