### PR TITLE
Max output data length modified in oozie-site.xml

### DIFF
--- a/salt/hdp/templates/cfg_pico.py.tpl
+++ b/salt/hdp/templates/cfg_pico.py.tpl
@@ -327,7 +327,8 @@ BLUEPRINT = r'''{
                     "oozie.service.JPAService.jdbc.url" : "jdbc:mysql://%(cluster_name)s-hadoop-mgr-1%(domain_name)s/oozie",
                     "oozie.service.JPAService.jdbc.driver" : "com.mysql.jdbc.Driver",
                     "oozie.authentication.type" : "simple",
-                    "oozie.db.schema.name" : "oozie"
+                    "oozie.db.schema.name" : "oozie",
+                    "oozie.servlet.CallbackServlet.max.data.len" : "16000"
                 }
             }
         },

--- a/salt/hdp/templates/cfg_production.py.tpl
+++ b/salt/hdp/templates/cfg_production.py.tpl
@@ -355,7 +355,8 @@ BLUEPRINT = r'''{
                     "oozie.service.JPAService.jdbc.url" : "jdbc:mysql://%(cluster_name)s-hadoop-mgr-4%(domain_name)s/oozie",
                     "oozie.service.JPAService.jdbc.driver" : "com.mysql.jdbc.Driver",
                     "oozie.authentication.type" : "simple",
-                    "oozie.db.schema.name" : "oozie"
+                    "oozie.db.schema.name" : "oozie",
+                    "oozie.servlet.CallbackServlet.max.data.len" : "16000"
                 }
             }
         },

--- a/salt/hdp/templates/cfg_standard.py.tpl
+++ b/salt/hdp/templates/cfg_standard.py.tpl
@@ -342,7 +342,8 @@ BLUEPRINT = r'''{
                     "oozie.service.JPAService.jdbc.url" : "jdbc:mysql://%(cluster_name)s-hadoop-mgr-4%(domain_name)s/oozie",
                     "oozie.service.JPAService.jdbc.driver" : "com.mysql.jdbc.Driver",
                     "oozie.authentication.type" : "simple",
-                    "oozie.db.schema.name" : "oozie"
+                    "oozie.db.schema.name" : "oozie",
+                    "oozie.servlet.CallbackServlet.max.data.len" : "16000"
                 }
             }
         },


### PR DESCRIPTION
Problem Statement:
PNDA-4875: Warning from CallbackServlet when running oozie job with SSH action

Analysis:
This is a known limitation of "capture-output" element of Oozie. This element is not designed to pass more than 2KB of data between workflow actions. Its default size was 2KB. So it gave the exception if SSH commands(STDOUT) output more than 2KB.

Changes:
To resolve this issue, Increased the limit from the default of 2048 bytes to 16000 bytes by setting Oozie "oozie.servlet.CallbackServlet.max.data.len" configuration property of oozie-site.xml.

Test Details,
RHEL - PICO-HDP