### PR TITLE
Change the platform testing package name according to the hadoop flavor

### DIFF
--- a/salt/gobblin/init.sls
+++ b/salt/gobblin/init.sls
@@ -4,9 +4,11 @@
 {% set gobblin_version = pillar['gobblin']['release_version'] %}
 
 {% if grains['hadoop.distro'] == 'HDP' %}
-{% set gobblin_package = 'gobblin-distribution-' + gobblin_version + '-HDP.tar.gz' %}
+{% set hadoop_version = pillar['hdp']['hadoop_version'] %}
+{% set gobblin_package = 'gobblin-distribution-' + gobblin_version + '-HDP-' + hadoop_version + '.tar.gz' %}
 {% else %}
-{% set gobblin_package = 'gobblin-distribution-' + gobblin_version + '-CDH.tar.gz' %}
+{% set hadoop_version = pillar['cloudera']['hadoop_version'] %}
+{% set gobblin_package = 'gobblin-distribution-' + gobblin_version + '-CDH-' + hadoop_version + '.tar.gz' %}
 {% endif %}
 
 {% set pnda_modules_version = pillar['platform_gobblin_modules']['release_version'] %}


### PR DESCRIPTION
Also, uses the cdh or hdp version number to differentiate the gobblin
build depending on the hadoop version used to compile.

PNDA-4899